### PR TITLE
Remove duplicate README titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
   </p>
 </div>
 
-<h1 align="center">Awesome DeepSeek Harness</h1>
-
 <p align="center">
   简体中文 · <a href="README_EN.md">English</a> · <a href="README_JA.md">日本語</a>
 </p>

--- a/README_EN.md
+++ b/README_EN.md
@@ -4,8 +4,6 @@
   </p>
 </div>
 
-<h1 align="center">Awesome DeepSeek Harness</h1>
-
 <p align="center">
   <a href="README.md">简体中文</a> · English · <a href="README_JA.md">日本語</a>
 </p>

--- a/README_JA.md
+++ b/README_JA.md
@@ -4,8 +4,6 @@
   </p>
 </div>
 
-<h1 align="center">Awesome DeepSeek Harness</h1>
-
 <p align="center">
   <a href="README.md">简体中文</a> · <a href="README_EN.md">English</a> · 日本語
 </p>


### PR DESCRIPTION
## What changed

- remove the duplicate centered H1 from the Chinese README
- remove the same H1 from the English and Japanese READMEs

## Why

The banner already provides the repository title, so the additional H1 is visually redundant.

## Validation

- `git diff --check`
- GitHub GFM rendering verified for all three README files
