### PR TITLE
docs: 收录 dsh-chat-import 插件条目

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ dsh --profile web --dump-config
 - [dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio)：编辑系统提示词片段并提供实时预览。
 - [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind)：基于持久 Change Ledger 回退对话和工作区状态。
 - [dsh-compaction-instant](https://github.com/KitDoesIt/dsh-compaction-instant)：以确定性编译替代 LLM 摘要，并通过 `recall` / `search` 恢复被压缩内容；替换内置压缩器时需要使用 npm alias，属于较深的运行时改造。
+- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import)：导入 Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode 的聊天记录，在 DSH 中重建为可继续（resume）的会话。
 
 ### 浏览器、视觉与界面
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -223,6 +223,7 @@ The following projects provide standalone user interfaces, distribution formats,
 - [dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio): edits system-prompt fragments with a live preview.
 - [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind): rewinds conversations and workspace state through a persistent Change Ledger.
 - [dsh-compaction-instant](https://github.com/KitDoesIt/dsh-compaction-instant): replaces LLM summarization with deterministic compilation and restores compressed content through `recall` / `search`; replacing the built-in compactor requires an npm alias and is a deeper runtime modification.
+- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import): imports chat histories from Claude Code, Codex, ChatGPT, Cursor, Gemini, Reasonix, and opencode into resumable DSH sessions.
 
 ### Browser, Vision, and Interface
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -223,6 +223,7 @@ Git リポジトリからインストールする場合は、commit を固定し
 - [dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio)：システムプロンプト断片を編集し、リアルタイムプレビューを表示。
 - [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind)：永続的な Change Ledger に基づき、会話とワークスペース状態を巻き戻す。
 - [dsh-compaction-instant](https://github.com/KitDoesIt/dsh-compaction-instant)：LLM 要約を決定論的コンパイルに置き換え、`recall` / `search` で圧縮された内容を復元。内蔵 compactor の置換には npm alias が必要で、Runtime への比較的深い変更となる。
+- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import)：Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode のチャット履歴をインポートし、DSH で再開可能（resume）なセッションとして再構築する。
 
 ### ブラウザ・ビジョン・インターフェース
 


### PR DESCRIPTION
## 收录说明

`dsh-chat-import` 是 DeepSeek Harness 的 Host 插件，可将 **7 种外部 AI 聊天记录**全保真导入为 **可继续（resume）** 的 DSH 会话：

- Claude Code（JSONL transcript）
- Codex / ChatGPT CLI（rollout JSONL）
- ChatGPT 网页导出（conversations.json）
- Cursor（agent transcript）
- Gemini CLI（session JSON）
- Reasonix（会话 JSONL）
- opencode（SQLite 历史库）

导入后保留文本、推理块、工具调用与结果、附件等，并可在 DSH 中直接继续对话；重复导入幂等跳过。仓库：https://github.com/Nwflower/dsh-chat-import

按「精选插件 → 上下文、会话与输入」分类收录，并同步更新 README_EN.md 与 README_JA.md 镜像。
