### PR TITLE
docs: add Harness Desktop distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ dsh --profile web --dump-config
 | [Oh-DSH-Desktop](https://github.com/hust-open-atom-club/oh-dsh-desktop) | macOS · Electron               | 打包 DSH Runtime、Node.js、PTY、工作区工具和插件市场预览的可扩展工作台                                                 |
 | [DSH Desktop](https://github.com/dataelement/dsh-desktop)               | macOS / Windows · Electron     | 管理本地 Harness、工作区、随机端口、Profile、插件和会话的跨平台桌面端                                                  |
 | [dsh-launcher](https://github.com/Ruler4396/dsh-launcher)               | Windows · WebView2             | 提供静默启动、独立窗口、便携包和 MSI 的轻量启动器                                                                      |
+| [Harness Desktop](https://github.com/baiyuscc13724-max/deepseek-harness-desktop) | Windows · Electron · 社区发行版 | 直接运行官方 DSH Web UI，提供中文安装包、便携版、SHA-256 校验更新，以及升级后仍保留的主题与自定义背景                  |
 
 ### 终端、移动与 Web 体验
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -186,6 +186,7 @@ The following projects provide standalone user interfaces, distribution formats,
 | [Oh-DSH-Desktop](https://github.com/hust-open-atom-club/oh-dsh-desktop) | macOS · Electron | Extensible workbench bundling the DSH Runtime, Node.js, PTY, workspace tools, and a plugin-market preview |
 | [DSH Desktop](https://github.com/dataelement/dsh-desktop) | macOS / Windows · Electron | Cross-platform desktop client for managing local Harness instances, workspaces, random ports, Profiles, plugins, and sessions |
 | [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Windows · WebView2 | Lightweight launcher with silent startup, a standalone window, portable packages, and MSI distribution |
+| [Harness Desktop](https://github.com/baiyuscc13724-max/deepseek-harness-desktop) | Windows · Electron · Community distribution | Runs the official DSH Web UI with a Simplified Chinese installer, portable build, SHA-256-verified updates, and themes and custom backgrounds that persist across upgrades |
 
 ### Terminal, Mobile, and Web Experiences
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -186,6 +186,7 @@ Git リポジトリからインストールする場合は、commit を固定し
 | [Oh-DSH-Desktop](https://github.com/hust-open-atom-club/oh-dsh-desktop) | macOS · Electron | DSH Runtime、Node.js、PTY、ワークスペースツール、プラグインマーケットのプレビューを同梱した拡張可能なワークベンチ |
 | [DSH Desktop](https://github.com/dataelement/dsh-desktop) | macOS / Windows · Electron | ローカル Harness、ワークスペース、ランダムポート、Profile、プラグイン、Session を管理するクロスプラットフォームデスクトップクライアント |
 | [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Windows · WebView2 | サイレント起動、独立ウィンドウ、ポータブルパッケージ、MSI を提供する軽量ランチャー |
+| [Harness Desktop](https://github.com/baiyuscc13724-max/deepseek-harness-desktop) | Windows · Electron · コミュニティ配布版 | 公式 DSH Web UI を直接実行し、簡体字中国語インストーラー、ポータブル版、SHA-256 検証付き更新、アップグレード後も保持されるテーマとカスタム背景を提供 |
 
 ### ターミナル・モバイル・Web 体験
 


### PR DESCRIPTION
Adds Harness Desktop to the Desktop Apps and Distributions tables in the Chinese, English, and Japanese READMEs.

The descriptions are limited to shipped features: the Windows Electron shell runs the official DSH Web UI and provides a Simplified Chinese installer, portable build, SHA-256-verified updates, and persistent themes with custom backgrounds.

The project is community-maintained and does not claim official DeepSeek endorsement.