### PR TITLE
Add DeepSeek Harness Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ dsh --profile web --dump-config
 | [TinyWhale](https://github.com/aimierbear/TinyWhale)                    | macOS · Electron · 发行版 Fork | 直接 Fork `deepseek-ai/deepseek-harness` 并增加独立桌面壳；连接已有 Web UI，或启动完整的 `dsh web` Runtime，不属于插件 |
 | [Oh-DSH-Desktop](https://github.com/hust-open-atom-club/oh-dsh-desktop) | macOS · Electron               | 打包 DSH Runtime、Node.js、PTY、工作区工具和插件市场预览的可扩展工作台                                                 |
 | [DSH Desktop](https://github.com/dataelement/dsh-desktop)               | macOS / Windows · Electron     | 管理本地 Harness、工作区、随机端口、Profile、插件和会话的跨平台桌面端                                                  |
+| [DeepSeek Harness Desktop](https://github.com/Stxr/deepseek-harness-desktop) | macOS / Windows · Electrobun | 启动官方 `dsh` Web Profile 的轻量桌面壳；内置固定版本的 Node.js、pnpm 与完整 CLI，并与命令行共享 `DSH_HOME` |
 | [dsh-launcher](https://github.com/Ruler4396/dsh-launcher)               | Windows · WebView2             | 提供静默启动、独立窗口、便携包和 MSI 的轻量启动器                                                                      |
 
 ### 终端、移动与 Web 体验

--- a/README_EN.md
+++ b/README_EN.md
@@ -185,6 +185,7 @@ The following projects provide standalone user interfaces, distribution formats,
 | [TinyWhale](https://github.com/aimierbear/TinyWhale) | macOS · Electron · Distribution fork | Directly forks `deepseek-ai/deepseek-harness` and adds a desktop shell; connects to an existing Web UI or launches a full `dsh web` Runtime, so it is not a plugin |
 | [Oh-DSH-Desktop](https://github.com/hust-open-atom-club/oh-dsh-desktop) | macOS · Electron | Extensible workbench bundling the DSH Runtime, Node.js, PTY, workspace tools, and a plugin-market preview |
 | [DSH Desktop](https://github.com/dataelement/dsh-desktop) | macOS / Windows · Electron | Cross-platform desktop client for managing local Harness instances, workspaces, random ports, Profiles, plugins, and sessions |
+| [DeepSeek Harness Desktop](https://github.com/Stxr/deepseek-harness-desktop) | macOS / Windows · Electrobun | Lightweight desktop shell that launches the official `dsh` Web Profile; bundles pinned Node.js, pnpm, and the full CLI while sharing `DSH_HOME` with the command line |
 | [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Windows · WebView2 | Lightweight launcher with silent startup, a standalone window, portable packages, and MSI distribution |
 
 ### Terminal, Mobile, and Web Experiences

--- a/README_JA.md
+++ b/README_JA.md
@@ -185,6 +185,7 @@ Git リポジトリからインストールする場合は、commit を固定し
 | [TinyWhale](https://github.com/aimierbear/TinyWhale) | macOS · Electron · ディストリビューション Fork | `deepseek-ai/deepseek-harness` を直接 Fork して独立デスクトップシェルを追加。既存 Web UI に接続するか、完全な `dsh web` Runtime を起動するため、プラグインではない |
 | [Oh-DSH-Desktop](https://github.com/hust-open-atom-club/oh-dsh-desktop) | macOS · Electron | DSH Runtime、Node.js、PTY、ワークスペースツール、プラグインマーケットのプレビューを同梱した拡張可能なワークベンチ |
 | [DSH Desktop](https://github.com/dataelement/dsh-desktop) | macOS / Windows · Electron | ローカル Harness、ワークスペース、ランダムポート、Profile、プラグイン、Session を管理するクロスプラットフォームデスクトップクライアント |
+| [DeepSeek Harness Desktop](https://github.com/Stxr/deepseek-harness-desktop) | macOS / Windows · Electrobun | 公式 `dsh` Web Profile を起動する軽量デスクトップシェル。固定版の Node.js、pnpm、完全な CLI を同梱し、コマンドラインと `DSH_HOME` を共有 |
 | [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Windows · WebView2 | サイレント起動、独立ウィンドウ、ポータブルパッケージ、MSI を提供する軽量ランチャー |
 
 ### ターミナル・モバイル・Web 体験


### PR DESCRIPTION
## What changed

- Add DeepSeek Harness Desktop to the desktop apps and distributions table.
- Keep the Chinese, English, and Japanese READMEs in sync.
- Describe the project as an Electrobun shell for the official `dsh` Web Profile, with bundled pinned Node.js, pnpm, the full CLI, and shared `DSH_HOME`.

## Why

This makes the macOS and Windows desktop client discoverable from the ecosystem guide while distinguishing it from projects that fork or rebuild the upstream Web UI.

## Impact

Documentation only. Existing entries and project behavior are unchanged.

## Validation

- `git diff --check`
- Verified the repository URL and feature claims against the project's README and package metadata.
