### PR TITLE
docs: 登记 dsh-chat-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ dsh --profile web --dump-config
 - [dsh-automation](https://github.com/titanwings/dsh-automation)：按计划在全新根 Agent 和 Session 中执行独立任务，保留定义修订、运行历史和明确的工作区与权限边界。
 - [dsh-plannotator](https://github.com/titanwings/dsh-plannotator)：对 Agent 计划逐段批注并提交结构化反馈，提供草稿隔离、版本绑定和过期计划拒绝。
 - [dsh-record-replay](https://github.com/humblebanana/dsh-record-replay)：录制 macOS 桌面工作流并生成 Skill；当前依赖 Xcode Command Line Tools 和独立的 `open-record-replay` 本地源码副本。
+- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import)：13 源全保真导入（Claude Code/Codex/ChatGPT/Cursor/Gemini/Reasonix/opencode/ZCode/Grok Build/OpenClaw/Pi/Hermes/Kimi）历史会话为可续聊 DSH 会话，并支持反向导出/同步回 Claude Code。
 
 ### 上下文、会话与输入
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-chat-import |
| 仓库 | https://github.com/Nwflower/dsh-chat-import |
| 一句话说明 | 13 种编码 Agent 聊天记录全保真导入为可续聊 DSH 会话，并支持反向导出/同步回 Claude Code |
| 版本 | 0.3.1（npm `dsh-chat-import`） |

## 自检清单

- [x] 仓库已打 `dsh-plugin` topic
- [x] npm 已发布（0.1.0–0.3.1），340 测试 + CI 全绿
- [x] 13 个 `import_*` 工具 + `scan_discover` / `export_claude` / `sync_to_claude` / `list_imported_sessions` / `retract_import` 实测通过

## 改动内容

在 `### 工作流与 Agent` 分类末尾（`dsh-record-replay` 之后）追加：

`- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import)：13 源全保真导入（Claude Code/Codex/ChatGPT/Cursor/Gemini/Reasonix/opencode/ZCode/Grok Build/OpenClaw/Pi/Hermes/Kimi）历史会话为可续聊 DSH 会话，并支持反向导出/同步回 Claude Code。`