### PR TITLE
Add Sealos Skills and refresh learning resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ dsh --profile web --dump-config
 
 ## 外部集成
 
+- [Sealos Skills](https://github.com/labring/sealos-skills)：由 Sealos 团队维护的 DSH Profile Bundle，提供应用部署、数据库、对象存储等八个云原生 Skills；实际使用会操作外部 Sealos Cloud 资源，需要账号与相关凭据，登录会写入 `~/.sealos/kubeconfig`，部分流程需放宽沙箱权限。`package.json` 声明 MIT，但仓库根目录当前缺少 `LICENSE` 文件。
 - [Nowledge Mem](https://mem.nowledge.co/integrations/deepseek-harness)：为 DSH 提供 Working Memory、提示时检索、MCP 工具和会话捕获；依赖外部 Nowledge Mem 产品与 `nmem` CLI，适合与开源插件分开评估。
 - [dsh-multica-runtime](https://github.com/forrestchang/dsh-multica-runtime)：连接 Multica 与 DSH 的早期运行时桥接；当前包标记为 `private`、`UNLICENSED`，安装与分发边界仍不完整。
 - [dsh-lark-bot](https://github.com/PlutoKeating/dsh-lark-bot)：把本地 DSH 接入飞书 / Lark，提供流式卡片、工作区、会话恢复与审批；采用 AGPL-3.0，应用凭据以权限 `600` 的明文配置保存在本机。

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@
   - [讨论社区](#讨论社区)
 - [社区资源](#社区资源)
   - [分析教程](#分析教程)
-  - [内测体验](#内测体验)
   - [社区讨论](#社区讨论)
 - [第三方客户端](#第三方客户端)
   - [桌面与发行版](#桌面与发行版)
@@ -151,17 +150,8 @@ dsh --profile web --dump-config
 | [解剖 DeepSeek Harness](https://xueai.app/slides/learn.html#dsh-1.html)         | 交互式源码专题  | 拆解会话、上下文、工具、沙箱、Code Mode 和 Subagent 等核心机制；部分内容需登录 |
 | [DeepSeek Harness 从零到一](https://yanhua1010.github.io/dsh-harness-tutorial/) | 中文教程与 Demo | 包含原理、源码拆解、8 个 Demo 和 `mini-harness` 教学项目；基于 `0.1.0-rc.6`    |
 | [Hello DSH](https://github.com/pingfanfan/hello-dsh/blob/main/README.zh.md)     | 插件入门与 Skill | 从终端安装讲到首个代码插件，附 22 个中文 Skill 示例、dry-run 与卸载流程；已在 `0.1.0-rc.6` 验证 |
+| [DeepSeek Harness：从开机到拆开](https://github.com/alchaincyf/deepseek-harness-orange-book) | 中文实测电子书 | 提供 PDF、EPUB 和 HTML，收录完整系统提示词、129 行默认启动清单与三份原始会话日志；写于发布后 24 小时内，内容可能随版本演进而变化 |
 
-### 内测体验
-
-以下内容来自参与 DSH 内测的开发者和插件作者，补充官方文档未覆盖的源码实践、插件开发与社区体验。
-
-| 文章                                                                                                                                                                                                                                                                                                          | 公众号             | 一手证据与推荐理由                                                                                                                                                                                                                                |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [《从 Vibe Coding 到 Vibe Assembly：我把 DeepSeek Harness 的官方 Agent Loop 换成了自己的》](https://mp.weixin.qq.com/s?src=11&timestamp=1786637084&ver=6902&signature=AmuyYYqPuPbw5G2jpJYbyn32WfqGpqQ5LFXWFbkahd791Xoyf5AHdeO0xALhXn7HBVWBPHrcKBA1-73Hzux4HNsbi3QRok89GJsW7GadbXAn4MMl5xxa9D7BZYd98ISQ&new=1) | 自然膨胀           | 作者自述收到内测邀请，并开发了替换 Agent Loop 的组装器；包含 76 轮自述对比实验与 Vibe Assembly 思考。相关项目：[TT-Wang/sliceagent](https://github.com/TT-Wang/sliceagent)                                                                        |
-| [《DeepSeek Harness 内测技术拆解：架构、生态、任务引擎与运维机制》](https://mp.weixin.qq.com/s?src=11&timestamp=1786636586&ver=6902&signature=5qBFaqg8tUoHqeaARYXZXqQR7TIhm6-A8hTn1l89K7fBYg75lM9%2AgkvFwRsFlpuNZxkOLFMp3Pz5RC0FXAVb5kSFba2A1f6OHfmA3Eb08bNBQi330OvXQaffRB2FKNI%2A&new=1)                     | cookbook之杂七杂八 | 作者自述连续跟踪十余天内测快照，并开发配套工具；覆盖 Cordis 事件、Session Log、Surface、上下文压缩、持久化与运维机制。相关项目：[fakechris/dsh-track](https://github.com/fakechris/dsh-track)                                                     |
-| [《DeepSeek Harness，可能是最能满足你想象力的 Agent Harness》](https://mp.weixin.qq.com/s?src=11&timestamp=1786636558&ver=6902&signature=ea1xi1hCFVZn4aDcUyC1SuFiyIr7xADTcQK%2AM1YmlXj2ffHZ6-ensj06csdXXayjppWFX00kyH8C7vTtl9EOEyfXLnWFmffmcqMmFAfdi8NApznAvYLtb11iP8%2AHjpgE&new=1)                          | GTOC               | 作者自述参与内测并移植 Humanize；讨论 Web UI 相比 TUI 的生态价值、Plugin 与 Skill 的区别、Trajectory 时间轴和产品化玩法。相关项目：[zevorn/dsh-humanize](https://github.com/zevorn/dsh-humanize)                                                  |
-| [《参与 dsh 内测有感》](https://mp.weixin.qq.com/s?src=11&timestamp=1786637135&ver=6902&signature=f2kUSJauxSlkVXP-gNNPIRTnOpnLFlErLe4br99jXqa5DQMhCDnbDWewbtAMfQ6VIMH0W6Ac95tZ4VyWhtAVyNZawkPrsAw5igtwqPl5lNxNl8Mhd9tbuMK3IW%2AAvojR&new=1)                                                                   | 减AI               | 作者明确自述入选内测，并公开了 [dsh-ads](https://github.com/Nagi-ovo/dsh-ads)、[dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) 和 [dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins)；适合观察插件作者如何理解早期生态。 |
 ### 社区讨论
 
 收录包含完整论述、实践细节或一手背景的公开社交媒体长帖，补充官方资料未覆盖的背景与实践细节。

--- a/README_EN.md
+++ b/README_EN.md
@@ -244,6 +244,7 @@ The following projects provide standalone user interfaces, distribution formats,
 
 ## External Integrations
 
+- [Sealos Skills](https://github.com/labring/sealos-skills): a DSH Profile Bundle maintained by the Sealos team, providing eight cloud-native Skills for application deployment, databases, object storage, and related workflows. Actual use changes external Sealos Cloud resources and requires an account and relevant credentials; login writes `~/.sealos/kubeconfig`, and some flows require a relaxed sandbox. `package.json` declares MIT, but the repository currently has no root `LICENSE` file.
 - [Nowledge Mem](https://mem.nowledge.co/integrations/deepseek-harness): adds Working Memory, prompt-time retrieval, MCP tools, and session capture to DSH; depends on the external Nowledge Mem product and `nmem` CLI and should be evaluated separately from open-source plugins.
 - [dsh-multica-runtime](https://github.com/forrestchang/dsh-multica-runtime): early runtime bridge connecting Multica and DSH; the package is currently marked `private` and `UNLICENSED`, with incomplete installation and distribution boundaries.
 - [dsh-lark-bot](https://github.com/PlutoKeating/dsh-lark-bot): connects local DSH to Feishu / Lark with streaming cards, workspaces, session recovery, and approvals; licensed under AGPL-3.0, with app credentials stored locally in plaintext configuration protected by mode `600`.

--- a/README_EN.md
+++ b/README_EN.md
@@ -38,7 +38,6 @@ This project follows a curated, quality-over-quantity approach to collecting exc
   - [Community](#community)
 - [Community Resources](#community-resources)
   - [Guides and Analysis](#guides-and-analysis)
-  - [Private Beta Experiences](#private-beta-experiences)
   - [Community Discussions](#community-discussions)
 - [Third-Party Clients](#third-party-clients)
   - [Desktop Apps and Distributions](#desktop-apps-and-distributions)
@@ -151,17 +150,7 @@ You are also welcome to join the Chinese DeepSeek Harness community. Scan the QR
 | [Dissecting DeepSeek Harness](https://xueai.app/slides/learn.html#dsh-1.html) | Interactive source-code course | Breaks down sessions, context, tools, sandboxing, Code Mode, Subagents, and other core mechanisms; some content requires signing in |
 | [DeepSeek Harness from Zero to One](https://yanhua1010.github.io/dsh-harness-tutorial/) | Chinese guide and demos | Covers concepts, source walkthroughs, eight demos, and a `mini-harness` teaching project; based on `0.1.0-rc.6` |
 | [Hello DSH](https://github.com/pingfanfan/hello-dsh) | Plugin introduction and Skills | Goes from terminal setup to a first code plugin, with 22 Chinese Skill examples, dry-run installation, and uninstall steps; verified on `0.1.0-rc.6` |
-
-### Private Beta Experiences
-
-The following articles come from DSH private-beta participants and plugin authors. They complement the official documentation with source-level practice, plugin development, and early community experience.
-
-| Article | WeChat Account | First-hand Evidence and Why It Matters |
-| --- | --- | --- |
-| [From Vibe Coding to Vibe Assembly: I Replaced DeepSeek Harness's Official Agent Loop](https://mp.weixin.qq.com/s?src=11&timestamp=1786637084&ver=6902&signature=AmuyYYqPuPbw5G2jpJYbyn32WfqGpqQ5LFXWFbkahd791Xoyf5AHdeO0xALhXn7HBVWBPHrcKBA1-73Hzux4HNsbi3QRok89GJsW7GadbXAn4MMl5xxa9D7BZYd98ISQ&new=1) | 自然膨胀 | The author states that they received a private-beta invitation and built an assembler that replaces the Agent Loop; includes a self-reported 76-round comparison and reflections on Vibe Assembly. Related project: [TT-Wang/sliceagent](https://github.com/TT-Wang/sliceagent) |
-| [DeepSeek Harness Private-Beta Technical Breakdown: Architecture, Ecosystem, Task Engine, and Operations](https://mp.weixin.qq.com/s?src=11&timestamp=1786636586&ver=6902&signature=5qBFaqg8tUoHqeaARYXZXqQR7TIhm6-A8hTn1l89K7fBYg75lM9%2AgkvFwRsFlpuNZxkOLFMp3Pz5RC0FXAVb5kSFba2A1f6OHfmA3Eb08bNBQi330OvXQaffRB2FKNI%2A&new=1) | cookbook之杂七杂八 | The author reports tracking private-beta snapshots for more than ten days and building supporting tools; covers Cordis events, Session Log, Surface, context compression, persistence, and operations. Related project: [fakechris/dsh-track](https://github.com/fakechris/dsh-track) |
-| [DeepSeek Harness May Be the Agent Harness That Best Matches Your Imagination](https://mp.weixin.qq.com/s?src=11&timestamp=1786636558&ver=6902&signature=ea1xi1hCFVZn4aDcUyC1SuFiyIr7xADTcQK%2AM1YmlXj2ffHZ6-ensj06csdXXayjppWFX00kyH8C7vTtl9EOEyfXLnWFmffmcqMmFAfdi8NApznAvYLtb11iP8%2AHjpgE&new=1) | GTOC | The author reports participating in the beta and porting Humanize; discusses the ecosystem value of the Web UI over a TUI, the difference between Plugins and Skills, the Trajectory timeline, and product possibilities. Related project: [zevorn/dsh-humanize](https://github.com/zevorn/dsh-humanize) |
-| [Thoughts After Participating in the DSH Private Beta](https://mp.weixin.qq.com/s?src=11&timestamp=1786637135&ver=6902&signature=f2kUSJauxSlkVXP-gNNPIRTnOpnLFlErLe4br99jXqa5DQMhCDnbDWewbtAMfQ6VIMH0W6Ac95tZ4VyWhtAVyNZawkPrsAw5igtwqPl5lNxNl8Mhd9tbuMK3IW%2AAvojR&new=1) | 减AI | The author explicitly states that they joined the beta and released [dsh-ads](https://github.com/Nagi-ovo/dsh-ads), [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize), and [dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins); useful for understanding how early plugin authors viewed the ecosystem. |
+| [DeepSeek Harness: From First Boot to Teardown](https://github.com/alchaincyf/deepseek-harness-orange-book) | Chinese hands-on ebook | Available as PDF, EPUB, and HTML, with the full system prompt, a 129-line default boot manifest, and three raw session logs; written within 24 hours of release, so details may change as DSH evolves |
 
 ### Community Discussions
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -244,6 +244,7 @@ Git リポジトリからインストールする場合は、commit を固定し
 
 ## 外部連携
 
+- [Sealos Skills](https://github.com/labring/sealos-skills)：Sealos チームが保守する DSH Profile Bundle。アプリのデプロイ、データベース、オブジェクトストレージなど、8 個のクラウドネイティブ Skill を提供。実際の利用では外部の Sealos Cloud リソースを変更するため、アカウントと関連認証情報が必要。ログイン時には `~/.sealos/kubeconfig` へ書き込み、一部のフローではサンドボックス権限の緩和が必要。`package.json` は MIT を宣言しているが、現在リポジトリのルートに `LICENSE` ファイルはない。
 - [Nowledge Mem](https://mem.nowledge.co/integrations/deepseek-harness)：DSH に Working Memory、プロンプト時の検索、MCP ツール、Session キャプチャを追加。外部製品 Nowledge Mem と `nmem` CLI に依存するため、オープンソースプラグインとは分けて評価するのが適切。
 - [dsh-multica-runtime](https://github.com/forrestchang/dsh-multica-runtime)：Multica と DSH を接続する初期段階の Runtime ブリッジ。現在パッケージは `private`、`UNLICENSED` とされ、インストールと配布の境界は未整備。
 - [dsh-lark-bot](https://github.com/PlutoKeating/dsh-lark-bot)：ローカル DSH を Feishu / Lark に接続し、ストリーミングカード、ワークスペース、Session 復元、承認を提供。AGPL-3.0 で、アプリ認証情報はモード `600` で保護されたローカルの平文設定に保存される。

--- a/README_JA.md
+++ b/README_JA.md
@@ -38,7 +38,6 @@
   - [コミュニティ](#コミュニティ)
 - [コミュニティリソース](#コミュニティリソース)
   - [解説とチュートリアル](#解説とチュートリアル)
-  - [クローズドベータ体験](#クローズドベータ体験)
   - [コミュニティでの議論](#コミュニティでの議論)
 - [サードパーティクライアント](#サードパーティクライアント)
   - [デスクトップアプリとディストリビューション](#デスクトップアプリとディストリビューション)
@@ -151,17 +150,7 @@ Git リポジトリからインストールする場合は、commit を固定し
 | [DeepSeek Harness を解剖する](https://xueai.app/slides/learn.html#dsh-1.html) | インタラクティブなソース解説 | Session、コンテキスト、ツール、サンドボックス、Code Mode、Subagent などの主要メカニズムを解説。一部はログインが必要 |
 | [DeepSeek Harness ゼロから入門](https://yanhua1010.github.io/dsh-harness-tutorial/) | 中国語チュートリアルと Demo | 原理、ソース解説、8 個の Demo、`mini-harness` 学習プロジェクトを収録。`0.1.0-rc.6` ベース |
 | [Hello DSH](https://github.com/pingfanfan/hello-dsh) | プラグイン入門と Skill | ターミナルでの導入から最初のコードプラグインまでを解説し、22 個の中国語 Skill 例、dry-run、アンインストール手順を収録。`0.1.0-rc.6` で検証済み |
-
-### クローズドベータ体験
-
-以下の記事は、DSH のクローズドベータ参加者やプラグイン作者によるものです。公式ドキュメントでは扱われていないソースレベルの実践、プラグイン開発、初期コミュニティの体験を補完します。
-
-| 記事 | WeChat アカウント | 一次情報と注目点 |
-| --- | --- | --- |
-| [Vibe Coding から Vibe Assembly へ：DeepSeek Harness 公式 Agent Loop を自作版に置き換えた](https://mp.weixin.qq.com/s?src=11&timestamp=1786637084&ver=6902&signature=AmuyYYqPuPbw5G2jpJYbyn32WfqGpqQ5LFXWFbkahd791Xoyf5AHdeO0xALhXn7HBVWBPHrcKBA1-73Hzux4HNsbi3QRok89GJsW7GadbXAn4MMl5xxa9D7BZYd98ISQ&new=1) | 自然膨胀 | 作者はベータ招待を受け、Agent Loop を置き換えるアセンブラーを開発したと説明。自己申告による 76 ラウンドの比較実験と Vibe Assembly に関する考察を含む。関連プロジェクト：[TT-Wang/sliceagent](https://github.com/TT-Wang/sliceagent) |
-| [DeepSeek Harness クローズドベータ技術解説：アーキテクチャ、エコシステム、タスクエンジン、運用](https://mp.weixin.qq.com/s?src=11&timestamp=1786636586&ver=6902&signature=5qBFaqg8tUoHqeaARYXZXqQR7TIhm6-A8hTn1l89K7fBYg75lM9%2AgkvFwRsFlpuNZxkOLFMp3Pz5RC0FXAVb5kSFba2A1f6OHfmA3Eb08bNBQi330OvXQaffRB2FKNI%2A&new=1) | cookbook之杂七杂八 | 作者は 10 日以上にわたりベータ版スナップショットを追跡し、補助ツールを開発したと説明。Cordis イベント、Session Log、Surface、コンテキスト圧縮、永続化、運用を扱う。関連プロジェクト：[fakechris/dsh-track](https://github.com/fakechris/dsh-track) |
-| [DeepSeek Harness は想像力を最も満たす Agent Harness かもしれない](https://mp.weixin.qq.com/s?src=11&timestamp=1786636558&ver=6902&signature=ea1xi1hCFVZn4aDcUyC1SuFiyIr7xADTcQK%2AM1YmlXj2ffHZ6-ensj06csdXXayjppWFX00kyH8C7vTtl9EOEyfXLnWFmffmcqMmFAfdi8NApznAvYLtb11iP8%2AHjpgE&new=1) | GTOC | 作者はベータ参加と Humanize の移植について説明。TUI と比べた Web UI のエコシステム価値、Plugin と Skill の違い、Trajectory タイムライン、プロダクト化の可能性を論じる。関連プロジェクト：[zevorn/dsh-humanize](https://github.com/zevorn/dsh-humanize) |
-| [DSH クローズドベータに参加して感じたこと](https://mp.weixin.qq.com/s?src=11&timestamp=1786637135&ver=6902&signature=f2kUSJauxSlkVXP-gNNPIRTnOpnLFlErLe4br99jXqa5DQMhCDnbDWewbtAMfQ6VIMH0W6Ac95tZ4VyWhtAVyNZawkPrsAw5igtwqPl5lNxNl8Mhd9tbuMK3IW%2AAvojR&new=1) | 减AI | 作者はベータへの参加を明記し、[dsh-ads](https://github.com/Nagi-ovo/dsh-ads)、[dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize)、[dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) を公開。初期プラグイン作者がエコシステムをどう捉えていたかを知る資料として有用 |
+| [DeepSeek Harness：起動から分解まで](https://github.com/alchaincyf/deepseek-harness-orange-book) | 中国語の実践電子書 | PDF、EPUB、HTML で公開。完全なシステムプロンプト、129 行のデフォルト起動マニフェスト、3 件の生セッションログを収録。リリース後 24 時間以内に執筆されたため、DSH の進化に伴い内容が変わる可能性がある |
 
 ### コミュニティでの議論
 


### PR DESCRIPTION
## Summary

- add Sealos Skills to the multilingual integrations catalog
- add the DeepSeek Harness Orange Book to the guides section
- remove the WeChat article section because its links do not provide a reliable reading experience
- keep the Chinese, English, and Japanese READMEs aligned

## Validation

- `git diff --check`
- rendered all three READMEs through the GitHub Markdown API
- confirmed no `mp.weixin.qq.com` article links remain

The two pre-existing untracked image files were not included.