### PR TITLE
Add dsh-bash-rtk to 开发工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ dsh --profile web --dump-config
 - [dsh-plugin-check](https://github.com/omdsh-dev/dsh-plugin-check)：检查 Manifest、Patch、构建陷阱和目录收录状态。
 - [dsh-fail-logger](https://github.com/Areium/dsh-fail-logger)：脱敏、去重并分类记录工具失败，将机器维护的实录沉淀进 Skill；只记录问题，不自动修改行为。
 - [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action)：在 GitHub Actions 中使用 DSH 做 PR Review、CI 诊断、自动修复和 Issue → PR；写权限默认关闭，并将验证放在无凭据容器中运行。
+- [dsh-bash-rtk](https://github.com/DeepTrial/dsh-bash-rtk)：在 DSH bash 执行器内把符合条件的 bash 命令路由给 rtk（Rust Token Killer）以压缩工具输出、节省 token；rtk 缺失时安全透传。
 - [dsh-suite](https://whyihaveyou.github.io/dsh-suite/zh.html)：中英双语 DSH 生态索引，提供插件搜索、`create-dsh-plugin` 脚手架和基础兼容性元数据；当前处于早期阶段，兼容性检查主要为静态依赖比对，安装与配置组装验证尚未完成。
 - [deepseek-harness-plugin-mcp](https://github.com/bobleer/deepseek-harness-plugin-mcp)：让其他 Agent 通过 MCP 发现、检查、安装和调用 DSH 插件；安装与运行默认关闭，只有显式启用 `--allow-install` / `--allow-runtime` 才会产生对应副作用。
 - [dsh-payload-capture](https://github.com/Moeblack/dsh-payload-capture)：捕获并落盘上行模型 API Payload，便于调试请求组装。


### PR DESCRIPTION
Hi maintainer,

Thank you for maintaining this curated Chinese-language guide to the DeepSeek Harness ecosystem.

I would like to propose adding **dsh-bash-rtk**, a DeepSeek Harness plugin I maintain:

- Repo: https://github.com/DeepTrial/dsh-bash-rtk
- What it does: routes eligible bash commands through [rtk](https://github.com/rtk-ai/rtk) (Rust Token Killer) inside the DSH bash executor to compress verbose tool output (git, cargo, pytest, docker, etc.) and reduce token usage. Complex commands, unknown tools, and runs without rtk on PATH pass through unchanged, so it is safe to enable.
- Compatibility: tested against DeepSeek Harness 0.1.0-rc.x; it requires an externally managed `rtk` binary on PATH.
- It is a real, public, MIT-licensed repository with a direct link and a one-line factual description, placed alphabetically in the 开发工具 section.

I kept the entry in the same Chinese-description style as the existing 开发工具 entries. Please let me know if you would prefer different wording or any additional detail. Thanks for your time and for maintaining the list.