### PR TITLE
docs: add dsh-sticky-disclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ dsh --profile web --dump-config
 - [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize)：在对话流中生成沙箱化的可交互 HTML 卡片。
 - [dsh-notification](https://github.com/omdsh-dev/dsh-notification)：按任务结果和关键词配置桌面通知。
 - [dsh-share](https://github.com/hellodigua/dsh-share)：一键生成并分享 DSH 对话内容。
+- [dsh-sticky-disclosure](https://github.com/Han-1413141/dsh-sticky-disclosure)：将滑出屏幕的 Think/工具/命令标签钉在 DSH Web 会话顶部，支持一键收起所有展开区块与自定义快捷键。
 
 ### 沙箱与执行
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -218,6 +218,7 @@ The following projects provide standalone user interfaces, distribution formats,
 - [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize): generates sandboxed, interactive HTML cards in the conversation stream.
 - [dsh-notification](https://github.com/omdsh-dev/dsh-notification): configurable desktop notifications based on task outcomes and keywords.
 - [dsh-share](https://github.com/hellodigua/dsh-share): generates and shares DSH conversation content in one click.
+- [dsh-sticky-disclosure](https://github.com/Han-1413141/dsh-sticky-disclosure): pins off-screen Think/tool/command labels to the top of the DSH Web conversation and collapses every expanded section in one click (custom hotkey).
 
 ### Sandboxing and Execution
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -218,6 +218,7 @@ Git リポジトリからインストールする場合は、commit を固定し
 - [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize)：会話ストリーム内にサンドボックス化されたインタラクティブ HTML カードを生成。
 - [dsh-notification](https://github.com/omdsh-dev/dsh-notification)：タスク結果とキーワードに応じて設定できるデスクトップ通知。
 - [dsh-share](https://github.com/hellodigua/dsh-share)：DSH の会話内容をワンクリックで生成・共有。
+- [dsh-sticky-disclosure](https://github.com/Han-1413141/dsh-sticky-disclosure)：画面外に出た Think/ツール/コマンドのラベルを DSH Web 会話の上部にピン留めし、展開済みセクションをワンクリックで折りたたむ（カスタムホットキー対応）。
 
 ### サンドボックスと実行
 


### PR DESCRIPTION
Add [dsh-sticky-disclosure](https://github.com/Han-1413141/dsh-sticky-disclosure) to the **浏览器、视觉与界面 / Browser, Vision, and Interface / ブラウザ・ビジョン・インターフェース** section in the Chinese, English, and Japanese READMEs.

It is a DSH Web client plugin that:
- pins off-screen expanded Think / tool / command labels to the top of the conversation;
- provides an always-visible collapse-all pill with a live count;
- supports a customizable hotkey (default `Ctrl+Alt+C`);
- is pure DOM, non-invasive, and installable with `dsh plugin --profile web add github:Han-1413141/dsh-sticky-disclosure`.
