### PR TITLE
add dsh-island: bridge DSH status to CodeIsland macOS notch panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ dsh --profile web --dump-config
 | [DSH Desktop](https://github.com/dataelement/dsh-desktop) | macOS / Windows · Electron           | 管理本地 Harness、工作区、随机端口、Profile、插件和会话的跨平台桌面端                                                  |
 | [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Windows · WebView2                   | 提供静默启动、独立窗口、便携包和 MSI 的轻量启动器                                                                      |
 
+- [cdxiaodong/dsh-island](https://github.com/cdxiaodong/dsh-island) - 通过 Unix socket 把 DSH agent 的会话、工具调用与审批实时桥接到 CodeIsland macOS 刘海面板，可直接在面板上批准/拒绝。
+
 ### 终端、移动与 Web 体验
 
 | 项目                                                            | 类型              | 说明                                                                                              |

--- a/README_EN.md
+++ b/README_EN.md
@@ -164,6 +164,8 @@ The following projects provide standalone user interfaces, distribution formats,
 | [DSH Desktop](https://github.com/dataelement/dsh-desktop) | macOS / Windows · Electron | Cross-platform desktop client for managing local Harness instances, workspaces, random ports, Profiles, plugins, and sessions |
 | [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Windows · WebView2 | Lightweight launcher with silent startup, a standalone window, portable packages, and MSI distribution |
 
+- [cdxiaodong/dsh-island](https://github.com/cdxiaodong/dsh-island) - Bridge DSH agent sessions, tool calls, and approvals to the CodeIsland macOS notch panel over a Unix socket, with in-panel allow/deny.
+
 ### Terminal, Mobile, and Web Experiences
 
 | Project | Type | Description |

--- a/README_JA.md
+++ b/README_JA.md
@@ -164,6 +164,8 @@ Git リポジトリからインストールする場合は、commit を固定し
 | [DSH Desktop](https://github.com/dataelement/dsh-desktop) | macOS / Windows · Electron | ローカル Harness、ワークスペース、ランダムポート、Profile、プラグイン、Session を管理するクロスプラットフォームデスクトップクライアント |
 | [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Windows · WebView2 | サイレント起動、独立ウィンドウ、ポータブルパッケージ、MSI を提供する軽量ランチャー |
 
+- [cdxiaodong/dsh-island](https://github.com/cdxiaodong/dsh-island) - Bridge DSH agent sessions, tool calls, and approvals to the CodeIsland macOS notch panel over a Unix socket, with in-panel allow/deny.
+
 ### ターミナル・モバイル・Web 体験
 
 | プロジェクト | 種類 | 説明 |


### PR DESCRIPTION
Adds dsh-island under 桌面与发行版.