### PR TITLE
Add `dsh-context` to 上下文、会话与输入

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ dsh --profile web --dump-config
 ### 上下文、会话与输入
 
 - [dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor)：审计 AGENTS.md、Skill 目录和工具 Schema 的上下文 Token 成本与冲突。
+- [dsh-context](https://github.com/bowenliang123/dsh-context)：上下文洞察面板——一眼看清模型上下文窗口的组成与变化（构成对照窗口大小、按请求历史趋势、压缩/注入事件、消息级 token 统计）。
 - [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve)：跨会话记忆、后台演进和分支感知能力。
 - [dsh-noema](https://github.com/ZSeven-W/dsh-noema)：为 DSH 接入本地优先的 Noema 长期记忆，支持工作前召回、设置页管理和从 Codex、Claude Code、Cursor 等导入已有记忆；MIT、`0.1.0-rc.1`，已在 DSH `0.1.0-rc.6` 验证，项目仍新，标注为早期。
 - [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file)：在输入框中通过 `@file` 搜索工作区文件并附加内容。


### PR DESCRIPTION
在「上下文、会话与输入」分类下新增 [dsh-context](https://github.com/bowenliang123/dsh-context)。

**上下文洞察面板**：在 Chat/Trajectory 旁新增 Context 标签页，一眼看清模型上下文窗口的组成与变化——构成对照窗口大小、按请求历史趋势、压缩/注入事件、消息级 token 统计。

安装：

```sh
dsh plugin --profile web add dsh-context
```

- 同时提供 dsh.bundle 清单（`dsh plugin add` 可装）与 web UI 半侧的 dsh.client 清单
- 已设置 `dsh-plugin` topic，Apache-2.0 许可
