### PR TITLE
docs: add dsh-self-evolving

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ dsh --profile web --dump-config
 - [dsh-plannotator](https://github.com/titanwings/dsh-plannotator)：对 Agent 计划逐段批注并提交结构化反馈，提供草稿隔离、版本绑定和过期计划拒绝。
 - [dsh-record-replay](https://github.com/humblebanana/dsh-record-replay)：录制 macOS 桌面工作流并生成 Skill；当前依赖 Xcode Command Line Tools 和独立的 `open-record-replay` 本地源码副本。
 - [dsh-science-workbench](https://github.com/poplarity/dsh-science-workbench)：面向可复现实验的工作台，把 Cell、图表、反馈与重跑链路记录到 Manifest，并保存环境快照和输入输出哈希；MIT、`v0.1.1`，功能仍处早期。
+- [dsh-self-evolving](https://github.com/timwhitez/dsh-self-evolving)：证据优先、可崩溃恢复的 DSH 自进化引擎，有界生成 Cordis 候选插件、经一次性真实 Loader 隔离准入、Harbor 评估，并保留可审计的日志化谱系；291 单测 + 36 Loader E2E，当前不声称 Terminal-Bench 提升。
 
 ### 上下文、会话与输入
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -193,6 +193,7 @@ The following projects provide standalone user interfaces, distribution formats,
 - [dsh-plannotator](https://github.com/titanwings/dsh-plannotator): annotates Agent plans section by section and submits structured feedback, with draft isolation, version binding, and stale-plan rejection.
 - [dsh-record-replay](https://github.com/humblebanana/dsh-record-replay): records macOS desktop workflows and generates Skills; currently requires Xcode Command Line Tools and a separate local `open-record-replay` source checkout.
 - [dsh-science-workbench](https://github.com/poplarity/dsh-science-workbench): reproducible science workbench that records cells, figures, feedback, and rerun lineage in a manifest, together with environment snapshots and input/output hashes; MIT and `v0.1.1`, still Early.
+- [dsh-self-evolving](https://github.com/timwhitez/dsh-self-evolving): evidence-first, crash-resumable self-evolution engine for DSH that generates bounded Cordis plugin candidates, admits them through a one-shot real Loader, evaluates with Harbor, and keeps an auditable journaled lineage; 291 unit tests + 36 Loader E2E, no Terminal-Bench improvement claimed.
 
 ### Context, Sessions, and Input
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -193,6 +193,7 @@ Git リポジトリからインストールする場合は、commit を固定し
 - [dsh-plannotator](https://github.com/titanwings/dsh-plannotator)：Agent の計画をセクションごとに注釈し、構造化フィードバックを送信。下書き分離、バージョン固定、古い計画の拒否に対応。
 - [dsh-record-replay](https://github.com/humblebanana/dsh-record-replay)：macOS デスクトップワークフローを記録して Skill を生成。現在は Xcode Command Line Tools と、別途用意した `open-record-replay` のローカルソースが必要。
 - [dsh-science-workbench](https://github.com/poplarity/dsh-science-workbench)：Cell、図、フィードバック、再実行の系譜を Manifest に記録し、環境 Snapshot と入出力 Hash も保存する再現可能な科学ワークベンチ。MIT、`v0.1.1` で、まだ初期段階。
+- [dsh-self-evolving](https://github.com/timwhitez/dsh-self-evolving)：エビデンス優先・クラッシュ復帰可能な DSH 自己進化エンジン。有界な Cordis プラグイン候補を生成し、ワンショットの実 Loader で隔離准入、Harbor で評価、監査可能なジャーナル系統を保持。291 ユニットテスト + 36 Loader E2E。Terminal-Bench 改善は主張していません。
 
 ### コンテキスト・Session・入力
 


### PR DESCRIPTION
Adds [timwhitez/dsh-self-evolving](https://github.com/timwhitez/dsh-self-evolving) to the Workflows and Agents section across zh / EN / JA.

One-line summary: evidence-first, crash-resumable self-evolution engine for DSH — bounded Cordis candidate generation, one-shot real-Loader admission, Harbor evaluation, auditable journaled lineage (291 unit tests + 36 real-Loader E2E; no Terminal-Bench improvement claim).