### PR TITLE
Add dsh-plugin-smooth-stream to Browser, Vision, and Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ dsh --profile web --dump-config
 - [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize)：在对话流中生成沙箱化的可交互 HTML 卡片。
 - [dsh-notification](https://github.com/omdsh-dev/dsh-notification)：按任务结果和关键词配置桌面通知。
 - [dsh-share](https://github.com/hellodigua/dsh-share)：一键生成并分享 DSH 对话内容。
+- [dsh-plugin-smooth-stream](https://github.com/SpookySandwich/dsh-plugin-smooth-stream)：以淡入的段落批次呈现助手回复，而非逐字输出，流式过程中平滑跟随滚动。
 
 ### 沙箱与执行
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -222,6 +222,7 @@ The following projects provide standalone user interfaces, distribution formats,
 - [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize): generates sandboxed, interactive HTML cards in the conversation stream.
 - [dsh-notification](https://github.com/omdsh-dev/dsh-notification): configurable desktop notifications based on task outcomes and keywords.
 - [dsh-share](https://github.com/hellodigua/dsh-share): generates and shares DSH conversation content in one click.
+- [dsh-plugin-smooth-stream](https://github.com/SpookySandwich/dsh-plugin-smooth-stream): reveals assistant replies in fading paragraph batches instead of token-by-token, with smooth scroll-follow while streaming.
 
 ### Sandboxing and Execution
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -222,6 +222,7 @@ Git リポジトリからインストールする場合は、commit を固定し
 - [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize)：会話ストリーム内にサンドボックス化されたインタラクティブ HTML カードを生成。
 - [dsh-notification](https://github.com/omdsh-dev/dsh-notification)：タスク結果とキーワードに応じて設定できるデスクトップ通知。
 - [dsh-share](https://github.com/hellodigua/dsh-share)：DSH の会話内容をワンクリックで生成・共有。
+- [dsh-plugin-smooth-stream](https://github.com/SpookySandwich/dsh-plugin-smooth-stream)：アシスタントの返答をトークン単位ではなくフェードインする段落単位で表示し、ストリーミング中はスクロールが滑らかに追従。
 
 ### サンドボックスと実行
 


### PR DESCRIPTION
Adds [dsh-plugin-smooth-stream](https://github.com/SpookySandwich/dsh-plugin-smooth-stream) under **Browser, Vision, and Interface**.

A client-only Web UI plugin: assistant replies are revealed in fading paragraph batches rather than token-by-token, scroll-follow stays smooth while streaming, and thinking blocks get a live summary line. `prefers-reduced-motion` is respected.

- Added to all three locales at the matching position — `README.md`, `README_EN.md`, `README_JA.md`
- Entry follows the existing format in each file (`- [name](url): description.`)
- Install: `dsh plugin --profile web add dsh-plugin-smooth-stream` — published on npm, declares a `dsh.bundle` manifest
- Verified loading against dsh `0.1.0-rc.6`
- MIT

Happy to reword the Japanese line if it reads unnaturally — I wrote it to match the surrounding entries' phrasing.