### PR TITLE
docs: 收录插件 dsh-captain-call（队长来电：AgentTeams 微信式语音通话插件）

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ dsh --profile web --dump-config
 - [dsh-auto-approval](https://github.com/Andy8647/dsh-auto-approval)：使用规则和模型分类工具调用，输出 `allow / deny` 自动审批决策。
 - [mstar-harness](https://github.com/btspoony/mstar-harness)：以 Skill 驱动的 Harness / Loop Engineering 工作流插件。
 - [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams)：为 DSH 提供 Agent Teams 能力。
+- [dsh-captain-call](https://github.com/Daisy2048/dsh-captain-call)：队长来电——让 AgentTeams 队员"打电话"给你：微信式来电界面、通讯录主动拨打、真实队员语音对话；内置 Kokoro-82M-zh（本地 102 款离线音色）与 Edge（14 款在线音色）双语音引擎，每人独立声线可选可试听；MIT，可通过 `dsh plugin --profile web add` 安装。
 - [dsh-automation](https://github.com/titanwings/dsh-automation)：按计划在全新根 Agent 和 Session 中执行独立任务，保留定义修订、运行历史和明确的工作区与权限边界。
 - [dsh-plannotator](https://github.com/titanwings/dsh-plannotator)：对 Agent 计划逐段批注并提交结构化反馈，提供草稿隔离、版本绑定和过期计划拒绝。
 - [dsh-record-replay](https://github.com/humblebanana/dsh-record-replay)：录制 macOS 桌面工作流并生成 Skill；当前依赖 Xcode Command Line Tools 和独立的 `open-record-replay` 本地源码副本。


### PR DESCRIPTION
## 插件信息

- 仓库：https://github.com/Daisy2048/dsh-captain-call
- 类型：Web UI Bundle 插件（`dsh plugin --profile web add` 安装）
- 功能：AgentTeams 队员完成任务时微信式来电 + 通讯录主动拨打 + 真实队员语音对话 + Kokoro-82M-zh（本地 102 款）/ Edge（在线 14 款）双语音引擎 + 每人独立声线选择
- 许可：MIT（头像/铃声素材版权见仓库 NOTICE）

已按 README 中“精选插件 → 工作流与 Agent”分类添加列表项，请审核。