### PR TITLE
Update curated DSH ecosystem resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ dsh --profile web --dump-config
 - [dsh-plannotator](https://github.com/titanwings/dsh-plannotator)：对 Agent 计划逐段批注并提交结构化反馈，提供草稿隔离、版本绑定和过期计划拒绝。
 - [dsh-record-replay](https://github.com/humblebanana/dsh-record-replay)：录制 macOS 桌面工作流并生成 Skill；当前依赖 Xcode Command Line Tools 和独立的 `open-record-replay` 本地源码副本。
 - [dsh-science-workbench](https://github.com/poplarity/dsh-science-workbench)：面向可复现实验的工作台，把 Cell、图表、反馈与重跑链路记录到 Manifest，并保存环境快照和输入输出哈希；MIT、`v0.1.1`，功能仍处早期。
+- [dsh-omicos](https://github.com/omicverse/dsh-omicos)：把 OmicOS 生物信息学能力接入 DSH，提供持久 Python / R 内核、能力目录、后台任务和执行过程视图；GPL-3.0-only、npm `0.2.1`。分析工具以 `permission_mode: full` 运行并可能启动本地内核，云模型和高级套餐需要 OmicOS 账号。
 
 ### 上下文、会话与输入
 
@@ -226,7 +227,8 @@ dsh --profile web --dump-config
 ### 沙箱与执行
 
 - [sandbox-micro](https://github.com/omdsh-dev/sandbox-micro)：提供 fail-closed 的 microsandbox microVM 能力；安装后 Provider 与模型工具均默认关闭，必须分别显式启用，平台检查失败时不会降级为无约束宿主执行。含测试目录但尚无正式 Release；`package.json` 声明 BSD-3-Clause，但仓库根目录没有 `LICENSE` 文件，标注为早期。
-- [dsh-win32](https://github.com/sjh9714/dsh-win32)：为 Windows 提供沙箱内可运行的持久 Shell、极简模式和 `doctor` 体检；MIT、`v0.9.3`，基于 DSH `0.1.0-rc.6`。可选的沙箱模式会下载 GPLv2 BusyBox，缺少 pnpm 时 `setup` 会通过 Corepack 启用，需明确知情后执行。
+- [dsh-credentials-keyring](https://github.com/irisnb/dsh-credentials-keyring)：用 Windows Credential Manager、macOS Keychain 或 Linux Secret Service 替代明文凭据文件，并在无 Secret Service 的 Linux 上 fail closed；MIT、`0.1.0`，有内存后端测试但尚无 npm / Release，真实系统钥匙串仍待逐平台烟测，标注为早期。
+- [dsh-win32](https://github.com/sjh9714/dsh-win32)：为 Windows 提供沙箱内可运行的持久 Shell、极简模式和 `doctor` 体检；MIT、`v0.12.0`，基于 DSH `0.1.0-rc.6`，现已修复 `SIGTERM`、管道和后台任务清理，并以 85 项测试和三系统矩阵验证。Windows 控制台进程在优雅终止失败后可能升级为强制终止；可选沙箱还会下载 GPLv2 BusyBox，缺少 pnpm 时 `setup` 会通过 Corepack 启用。
 
 ### 主题与皮肤
 
@@ -240,8 +242,10 @@ dsh --profile web --dump-config
 - [Open Design](https://github.com/nexu-io/open-design)：本地优先的开源设计应用，通过原生 DSH Runtime 适配提供结构化流式输出、模型发现、取消和会话恢复；Apache-2.0，属于大型独立产品而非普通插件。
 - [dsh-multica-runtime](https://github.com/forrestchang/dsh-multica-runtime)：连接 Multica 与 DSH 的早期运行时桥接；当前包标记为 `private`、`UNLICENSED`，安装与分发边界仍不完整。
 - [dsh-lark-bot](https://github.com/PlutoKeating/dsh-lark-bot)：把本地 DSH 接入飞书 / Lark，提供流式卡片、工作区、会话恢复与审批；采用 AGPL-3.0，应用凭据以权限 `600` 的明文配置保存在本机。
+- [dsh-lark](https://github.com/sugarforever/dsh-lark)：使用飞书官方 Node SDK 和 WebSocket 长连接把 DSH 接入飞书 / Lark，无需公网回调；MIT、npm / GitHub `v0.1.1`。默认只申请三项消息权限，凭据从环境变量读取；实际运行会接收并以机器人身份发送外部消息。
 - [dsh-qqbot](https://github.com/tencent-connect/dsh-qqbot)：腾讯团队维护的 QQ Bot 插件，支持扫码绑定、私聊与群聊会话隔离及重启恢复；MIT、`0.1.0`，绑定过程会把凭据保存到本地 Profile。
 - [LoongSuite DSH Plugin](https://github.com/loongsuite/dsh-plugin)：把 Agent Turn、模型调用、工具执行和 Token 使用转成 OpenTelemetry GenAI Trace，可发送到 Jaeger、Tempo、SigNoz、Langfuse 等 OTLP 后端；Apache-2.0、Beta，已在 DSH `0.1.0-rc.6` 的 Headless 与 Web Profile 验证。内容采集默认关闭，启用后可能外发源码、凭据和个人数据。
+- [dsh-wakatime](https://github.com/dingyi222666/dsh-wakatime)：把 DSH 文件操作、AI 代码行数和项目耗时上报到 WakaTime；MIT、npm `0.1.1`，有测试但项目仍新，标注为早期。需要 WakaTime API Key，会写入 `~/.wakatime/dsh-wakatime/` 并在缺少 CLI 时自动下载或更新 `wakatime-cli`。
 
 ## 开发工具
 
@@ -256,6 +260,8 @@ dsh --profile web --dump-config
 - [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool)：通过 Monaco 编辑器创建和管理沙箱化 JavaScript 工具。
 - [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode)：从 Web UI 直接在 VS Code 中打开当前工作区。
 - [dsh-movein](https://github.com/sjh9714/dsh-movein)：一条命令把 Claude Code 的 Skills、MCP、hooks 和全局指令迁入 DSH；默认预演，`CLAUDE.md` 由 DSH 原生读取，会话历史不在范围内。MIT，已在 DSH `0.1.0-rc.6` 验证，项目仍新，标注为早期。
+- [dshpack](https://github.com/hili986/dshpack)：把 Skills、MCP、Profile Patch 和权限默认值打包成可安装、可分享、可审计的 DSH Profile；默认拒绝构建脚本，支持 dry-run、固定来源、凭据扫描和事务回滚。MIT、M0 预发布，尚无 npm，`init` / `pack` 仍未实现，标注为早期。
+- [hooks-adapter](https://github.com/JohnXu22786/hooks-adapter)：让 DSH 直接复用 Claude Code、Codex 和 OpenCode 的 hooks 配置，并提供 Shell、Webhook、LLM 与子 Agent Handler；MIT、仓库声明 111 项测试但尚无 Release，自动发现的 hooks 可执行命令和外发数据，标注为早期。
 
 ## 致谢
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -193,6 +193,7 @@ The following projects provide standalone user interfaces, distribution formats,
 - [dsh-plannotator](https://github.com/titanwings/dsh-plannotator): annotates Agent plans section by section and submits structured feedback, with draft isolation, version binding, and stale-plan rejection.
 - [dsh-record-replay](https://github.com/humblebanana/dsh-record-replay): records macOS desktop workflows and generates Skills; currently requires Xcode Command Line Tools and a separate local `open-record-replay` source checkout.
 - [dsh-science-workbench](https://github.com/poplarity/dsh-science-workbench): reproducible science workbench that records cells, figures, feedback, and rerun lineage in a manifest, together with environment snapshots and input/output hashes; MIT and `v0.1.1`, still Early.
+- [dsh-omicos](https://github.com/omicverse/dsh-omicos): connects OmicOS bioinformatics to DSH with a persistent Python / R kernel, capability catalog, background jobs, and live execution views; GPL-3.0-only and published to npm as `0.2.1`. Analysis tools run with `permission_mode: full` and may start a local kernel; cloud-backed models and higher tiers require an OmicOS account.
 
 ### Context, Sessions, and Input
 
@@ -226,7 +227,8 @@ The following projects provide standalone user interfaces, distribution formats,
 ### Sandboxing and Execution
 
 - [sandbox-micro](https://github.com/omdsh-dev/sandbox-micro): provides a fail-closed microsandbox microVM capability; both the Provider and model-facing tools stay disabled after installation until separately enabled, and failed platform checks never degrade to unconstrained host execution. It has test directories but no formal Release; `package.json` declares BSD-3-Clause, but the repository has no root `LICENSE` file, so it is marked Early.
-- [dsh-win32](https://github.com/sjh9714/dsh-win32): Windows persistent shell that works inside the sandbox, plus a minimal mode and `doctor` diagnostics; MIT and `v0.9.3`, built against DSH `0.1.0-rc.6`. Its optional sandboxed mode downloads GPLv2 BusyBox, and `setup` enables pnpm through Corepack when missing, so run it only with informed consent.
+- [dsh-credentials-keyring](https://github.com/irisnb/dsh-credentials-keyring): replaces plaintext credential files with Windows Credential Manager, macOS Keychain, or Linux Secret Service, and fails closed on Linux without Secret Service; MIT `0.1.0`, with in-memory backend tests but no npm package or Release yet. Real OS keychains still need per-platform smoke tests, so it is marked Early.
+- [dsh-win32](https://github.com/sjh9714/dsh-win32): Windows persistent shell that works inside the sandbox, plus a minimal mode and `doctor` diagnostics; MIT `v0.12.0`, built against DSH `0.1.0-rc.6`, now fixing `SIGTERM`, pipeline, and background-job cleanup with 85 tests and a three-OS matrix. Windows console processes may escalate to forced termination after graceful termination fails; the optional sandbox also downloads GPLv2 BusyBox, and `setup` enables pnpm through Corepack when missing.
 
 ### Themes and Skins
 
@@ -240,8 +242,10 @@ The following projects provide standalone user interfaces, distribution formats,
 - [Open Design](https://github.com/nexu-io/open-design): local-first open-source design application with a native DSH runtime adapter for structured streaming, model discovery, cancellation, and session resume; Apache-2.0 and a large standalone product rather than an ordinary plugin.
 - [dsh-multica-runtime](https://github.com/forrestchang/dsh-multica-runtime): early runtime bridge connecting Multica and DSH; the package is currently marked `private` and `UNLICENSED`, with incomplete installation and distribution boundaries.
 - [dsh-lark-bot](https://github.com/PlutoKeating/dsh-lark-bot): connects local DSH to Feishu / Lark with streaming cards, workspaces, session recovery, and approvals; licensed under AGPL-3.0, with app credentials stored locally in plaintext configuration protected by mode `600`.
+- [dsh-lark](https://github.com/sugarforever/dsh-lark): connects DSH to Feishu / Lark through the official Node SDK and a WebSocket connection, without a public callback endpoint; MIT and npm / GitHub `v0.1.1`. It requests only three message scopes by default and reads credentials from environment variables; actual use receives and sends external messages as the bot.
 - [dsh-qqbot](https://github.com/tencent-connect/dsh-qqbot): Tencent-maintained QQ Bot plugin with QR-code binding, isolated direct/group sessions, and restart recovery; MIT and `0.1.0`, with credentials saved to the local Profile during binding.
 - [LoongSuite DSH Plugin](https://github.com/loongsuite/dsh-plugin): converts Agent turns, model calls, tool executions, and token usage into OpenTelemetry GenAI traces for OTLP backends such as Jaeger, Tempo, SigNoz, and Langfuse; Apache-2.0 and Beta, tested with DSH `0.1.0-rc.6` in headless and Web profiles. Content capture is off by default; enabling it may export source code, credentials, and personal data.
+- [dsh-wakatime](https://github.com/dingyi222666/dsh-wakatime): reports DSH file activity, AI line changes, and project time to WakaTime; MIT and npm `0.1.1`, with tests but still new and marked Early. It requires a WakaTime API key, writes state under `~/.wakatime/dsh-wakatime/`, and automatically downloads or updates `wakatime-cli` when absent.
 
 ## Developer Tools
 
@@ -256,6 +260,8 @@ The following projects provide standalone user interfaces, distribution formats,
 - [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool): creates and manages sandboxed JavaScript tools through a Monaco editor.
 - [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode): opens the current workspace directly in VS Code from the Web UI.
 - [dsh-movein](https://github.com/sjh9714/dsh-movein): moves Claude Code Skills, MCP servers, hooks, and global instructions into DSH with one command; dry-run by default, `CLAUDE.md` is read natively, and session history is out of scope. MIT, verified on DSH `0.1.0-rc.6`, still new and marked Early.
+- [dshpack](https://github.com/hili986/dshpack): packages Skills, MCP servers, Profile patches, and permission defaults into installable, shareable, auditable DSH Profiles; build scripts are denied by default, with dry-run planning, pinned sources, credential scanning, and transactional rollback. MIT and M0 prerelease, not yet on npm, with `init` / `pack` still unimplemented, so marked Early.
+- [hooks-adapter](https://github.com/JohnXu22786/hooks-adapter): lets DSH reuse Claude Code, Codex, and OpenCode hooks configs directly, with Shell, Webhook, LLM, and Subagent handlers; MIT, claiming 111 repository tests but no Release yet. Auto-discovered hooks can execute commands and transmit data, so it is marked Early.
 
 ## Acknowledgements
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -193,6 +193,7 @@ Git リポジトリからインストールする場合は、commit を固定し
 - [dsh-plannotator](https://github.com/titanwings/dsh-plannotator)：Agent の計画をセクションごとに注釈し、構造化フィードバックを送信。下書き分離、バージョン固定、古い計画の拒否に対応。
 - [dsh-record-replay](https://github.com/humblebanana/dsh-record-replay)：macOS デスクトップワークフローを記録して Skill を生成。現在は Xcode Command Line Tools と、別途用意した `open-record-replay` のローカルソースが必要。
 - [dsh-science-workbench](https://github.com/poplarity/dsh-science-workbench)：Cell、図、フィードバック、再実行の系譜を Manifest に記録し、環境 Snapshot と入出力 Hash も保存する再現可能な科学ワークベンチ。MIT、`v0.1.1` で、まだ初期段階。
+- [dsh-omicos](https://github.com/omicverse/dsh-omicos)：OmicOS のバイオインフォマティクス機能を DSH に接続し、永続 Python / R Kernel、Capability Catalog、Background Job、実行状況 View を提供。GPL-3.0-only、npm `0.2.1`。分析 Tool は `permission_mode: full` で動作し、ローカル Kernel を起動する場合がある。Cloud Model と上位 Plan には OmicOS Account が必要。
 
 ### コンテキスト・Session・入力
 
@@ -226,7 +227,8 @@ Git リポジトリからインストールする場合は、commit を固定し
 ### サンドボックスと実行
 
 - [sandbox-micro](https://github.com/omdsh-dev/sandbox-micro)：fail-closed な microsandbox microVM 能力を提供。導入後も Provider とモデル向け Tool は個別に明示有効化するまで無効で、プラットフォーム検査に失敗しても無制限の Host 実行へフォールバックしない。テストディレクトリはあるが正式 Release はなく、`package.json` は BSD-3-Clause を宣言する一方でルートに `LICENSE` ファイルがないため初期段階。
-- [dsh-win32](https://github.com/sjh9714/dsh-win32)：Windows 向けに Sandbox 内で動作する永続 Shell、Minimal Mode、`doctor` 診断を提供。MIT、`v0.9.3`、DSH `0.1.0-rc.6` ベース。任意の Sandboxed Mode は GPLv2 BusyBox を Download し、pnpm がなければ `setup` が Corepack 経由で有効化するため、内容を理解したうえで実行する必要がある。
+- [dsh-credentials-keyring](https://github.com/irisnb/dsh-credentials-keyring)：平文 Credential File を Windows Credential Manager、macOS Keychain、Linux Secret Service に置き換え、Secret Service のない Linux では fail closed。MIT `0.1.0` で Memory Backend Test はあるが npm / Release はまだなく、実 OS Keychain の Platform 別 Smoke Test も未完了のため初期段階。
+- [dsh-win32](https://github.com/sjh9714/dsh-win32)：Windows 向けに Sandbox 内で動作する永続 Shell、Minimal Mode、`doctor` 診断を提供。MIT `v0.12.0`、DSH `0.1.0-rc.6` ベース。`SIGTERM`、Pipeline、Background Job の Cleanup を修正し、85 Test と 3 OS Matrix で検証。Windows Console Process は Graceful Termination 失敗後に Force Kill へ進む場合がある。任意 Sandbox は GPLv2 BusyBox を Download し、pnpm がなければ `setup` が Corepack で有効化する。
 
 ### テーマとスキン
 
@@ -240,8 +242,10 @@ Git リポジトリからインストールする場合は、commit を固定し
 - [Open Design](https://github.com/nexu-io/open-design)：構造化 Streaming、モデル検出、Cancel、Session 再開に対応する DSH ネイティブ Runtime Adapter を備えた Local-first のオープンソースデザインアプリ。Apache-2.0 で、通常のプラグインではなく大規模な独立製品。
 - [dsh-multica-runtime](https://github.com/forrestchang/dsh-multica-runtime)：Multica と DSH を接続する初期段階の Runtime ブリッジ。現在パッケージは `private`、`UNLICENSED` とされ、インストールと配布の境界は未整備。
 - [dsh-lark-bot](https://github.com/PlutoKeating/dsh-lark-bot)：ローカル DSH を Feishu / Lark に接続し、ストリーミングカード、ワークスペース、Session 復元、承認を提供。AGPL-3.0 で、アプリ認証情報はモード `600` で保護されたローカルの平文設定に保存される。
+- [dsh-lark](https://github.com/sugarforever/dsh-lark)：公式 Node SDK と WebSocket 長接続で DSH を Feishu / Lark に接続し、Public Callback Endpoint は不要。MIT、npm / GitHub `v0.1.1`。既定では Message Scope 3 項目のみを要求し、Credential は Environment Variable から読む。実行時は Bot として外部 Message を受信・送信する。
 - [dsh-qqbot](https://github.com/tencent-connect/dsh-qqbot)：Tencent が管理する QQ Bot プラグイン。QR Code 連携、Private/Group Session の分離、再起動後の復元に対応。MIT、`0.1.0` で、連携時に認証情報をローカル Profile へ保存する。
 - [LoongSuite DSH Plugin](https://github.com/loongsuite/dsh-plugin)：Agent Turn、Model Call、Tool 実行、Token 使用量を OpenTelemetry GenAI Trace に変換し、Jaeger、Tempo、SigNoz、Langfuse などの OTLP Backend へ送信する。Apache-2.0、Beta で、DSH `0.1.0-rc.6` の Headless / Web Profile で検証済み。Content Capture は既定で無効だが、有効化すると Source Code、Credential、個人情報が外部へ送られる可能性がある。
+- [dsh-wakatime](https://github.com/dingyi222666/dsh-wakatime)：DSH の File Activity、AI Line Change、Project Time を WakaTime へ送信。MIT、npm `0.1.1`。Test はあるが新しいため初期段階。WakaTime API Key が必要で、`~/.wakatime/dsh-wakatime/` に State を書き、CLI がなければ `wakatime-cli` を自動 Download / Update する。
 
 ## 開発ツール
 
@@ -256,6 +260,8 @@ Git リポジトリからインストールする場合は、commit を固定し
 - [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool)：Monaco エディターでサンドボックス化された JavaScript ツールを作成・管理。
 - [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode)：Web UI から現在のワークスペースを VS Code で直接開く。
 - [dsh-movein](https://github.com/sjh9714/dsh-movein)：1 コマンドで Claude Code の Skill、MCP、hooks、グローバル指示を DSH へ移行。デフォルトはドライラン。`CLAUDE.md` は DSH がネイティブに読み、Session 履歴は対象外。MIT。DSH `0.1.0-rc.6` で検証済みだが新しいため初期段階。
+- [dshpack](https://github.com/hili986/dshpack)：Skill、MCP、Profile Patch、Permission Default を Install・共有・監査可能な DSH Profile に Package 化。Build Script は既定で拒否し、dry-run、Source Pin、Credential Scan、Transaction Rollback を備える。MIT、M0 Prerelease、npm 未公開で `init` / `pack` も未実装のため初期段階。
+- [hooks-adapter](https://github.com/JohnXu22786/hooks-adapter)：Claude Code、Codex、OpenCode の hooks Config を DSH で直接再利用し、Shell、Webhook、LLM、Subagent Handler を提供。MIT、Repository は 111 Test を示すが Release はまだない。自動検出した hooks は Command 実行や Data 送信が可能なため初期段階。
 
 ## 謝辞
 


### PR DESCRIPTION
## What changed

- Add six evidence-reviewed DSH ecosystem projects across the Chinese, English, and Japanese catalogs.
- Update dsh-win32 from v0.9.3 to v0.12.0 with its Windows process-cleanup behavior and validation evidence.
- Preserve install, license, maturity, credential, telemetry, and external-side-effect boundaries in every language.

## Why

The August 17 ecosystem scan found a small set of distinct, source-verifiable additions amid a very high volume of new GitHub repositories. This update keeps the catalog selective while recording the most material new integrations and safety boundaries.

## Impact

Documentation only. No runtime code, dependencies, or repository assets are changed.

## Checks

- git diff --check
- GitHub GFM rendering for all three README files
- GitHub URL parity: 85 unique URLs in each language
- Only README.md, README_EN.md, and README_JA.md are included in the commit