### PR TITLE
添加 xgone/dsh-remote 插件（远程访问与认证）

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ dsh --profile web --dump-config
 - [dsh-movein](https://github.com/sjh9714/dsh-movein)：一条命令把 Claude Code 的 Skills、MCP、hooks 和全局指令迁入 DSH；默认预演，`CLAUDE.md` 由 DSH 原生读取，会话历史不在范围内。MIT，已在 DSH `0.1.0-rc.6` 验证，项目仍新，标注为早期。
 - [dshpack](https://github.com/hili986/dshpack)：把 Skills、MCP、Profile Patch 和权限默认值打包成可安装、可分享、可审计的 DSH Profile；默认拒绝构建脚本，支持 dry-run、固定来源、凭据扫描和事务回滚。MIT、M0 预发布，尚无 npm，`init` / `pack` 仍未实现，标注为早期。
 - [hooks-adapter](https://github.com/JohnXu22786/hooks-adapter)：让 DSH 直接复用 Claude Code、Codex 和 OpenCode 的 hooks 配置，并提供 Shell、Webhook、LLM 与子 Agent Handler；MIT、仓库声明 111 项测试但尚无 Release，自动发现的 hooks 可执行命令和外发数据，标注为早期。
+- [xgone/dsh-remote](https://github.com/xgone/dsh-remote)：DeepSeek Harness 网页端远程访问与认证：账号/密码登录门、MFA（TOTP 两步验证）、签名会话 Cookie、基于角色的访问控制、浏览器内目录选择器，以及账号管理设置页，支持中英双语。
 
 ## 致谢
 


### PR DESCRIPTION
收录 [xgone/dsh-remote](https://github.com/xgone/dsh-remote)（npm: `@xgone/dsh-remote`，v0.1.2）——DeepSeek Harness 网页端远程访问与认证：登录门、MFA（TOTP）、签名会话 Cookie、基于角色的访问控制、浏览器内目录选择器与账号管理设置页，界面支持中英双语。安装：`dsh plugin --profile web add @xgone/dsh-remote`