### PR TITLE
Update DSH ecosystem entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@
 
 [DeepSeek Harness](https://deepseek.com/harness/)（简称 DSH 或 `dsh`）是 DeepSeek AI 开源的 Agent Harness 项目。它基于 [Cordis](https://github.com/cordiverse/cordis)，采用 **Everything is a Plugin（一切皆插件）** 的架构：模型适配器、工具、会话日志、界面和 Agent Loop 都可以通过插件树组合与替换。
 
+当前核验到的官方开发者预览版为 [`0.1.0-rc.7`](https://github.com/deepseek-ai/deepseek-harness/tree/dsh-v0.1.0-rc.7)。下方各项目标注的 DSH 版本表示其作者实际声明的开发或测试基线，不应自动视为已兼容最新预览版。
+
 ### 启动 Web UI
 
 安装 [Node.js](https://nodejs.org/) 22.19.x 或 24+（推荐 24+）后执行：
@@ -194,6 +196,8 @@ dsh --profile web --dump-config
 - [dsh-record-replay](https://github.com/humblebanana/dsh-record-replay)：录制 macOS 桌面工作流并生成 Skill；当前依赖 Xcode Command Line Tools 和独立的 `open-record-replay` 本地源码副本。
 - [dsh-science-workbench](https://github.com/poplarity/dsh-science-workbench)：面向可复现实验的工作台，把 Cell、图表、反馈与重跑链路记录到 Manifest，并保存环境快照和输入输出哈希；MIT、`v0.1.1`，功能仍处早期。
 - [dsh-omicos](https://github.com/omicverse/dsh-omicos)：把 OmicOS 生物信息学能力接入 DSH，提供持久 Python / R 内核、能力目录、后台任务和执行过程视图；GPL-3.0-only、npm `0.2.1`。分析工具以 `permission_mode: full` 运行并可能启动本地内核，云模型和高级套餐需要 OmicOS 账号。
+- [dsh-crew](https://github.com/ZSeven-W/dsh-crew)：从 Claude Code 或 Codex 调度真实 DSH Worker，并提供进度、状态分片和分层策略；MIT、npm `0.1.0-rc.1`，会写入 `~/.config/dsh-crew/status.d/`，外部模型服务可能需要 API Key。当前仅声明在 DSH `0.1.0-rc.6` 验证，且尚无可见测试，标注为早期。
+- [dsh-trading](https://github.com/maddogfinance/dsh-trading)：面向交易研究的 DSH 工作台，提供确定性指标、CSV 数据源和交互式图表；MIT、npm `@dsh-trading/bundle@0.1.0`。项目不提供订单执行接口，并以启发式规则拦截资金移动类工具，但该拦截并非完备安全边界，标注为早期。
 
 ### 上下文、会话与输入
 
@@ -205,7 +209,8 @@ dsh --profile web --dump-config
 - [dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio)：编辑系统提示词片段并提供实时预览。
 - [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind)：基于持久 Change Ledger 回退对话和工作区状态。
 - [dsh-compaction-instant](https://github.com/KitDoesIt/dsh-compaction-instant)：以确定性编译替代 LLM 摘要，并通过 `recall` / `search` 恢复被压缩内容；替换内置压缩器时需要使用 npm alias，属于较深的运行时改造。
-- [dsh-whale-report](https://github.com/SenmuuuuW/dsh-whale-report)：从会话事件日志只读生成日报、周报、月报、年报和自定义区间报告，不改写会话历史；MIT、`v0.2.0`，仍属早期。
+- [toolshrink](https://github.com/unclecode/toolshrink)：按测试、Diff、JSON、目录树、日志和安装输出的结构做内容感知压缩，并在需要时保留原始输出引用；MIT、`0.1.0`，目前需从源码构建并修改全局 `~/.dsh/cordis.patch.yml`，暂存的原始输出会在 24 小时后清理，标注为早期。
+- [dsh-whale-report](https://github.com/SenmuuuuW/dsh-whale-report)：从会话事件日志只读生成日报、周报、月报、年报和自定义区间报告，并在 `v0.4.0` 增加 DeepTrace、成本与余额、发现项、协作、活动、资源、风险和 Session Trace；不改写会话历史，MIT，仍属早期。
 
 ### 浏览器、视觉与界面
 
@@ -236,6 +241,7 @@ dsh --profile web --dump-config
 
 ## 外部集成
 
+- [dsh-oomol](https://github.com/oomol-lab/dsh-oomol)：通过 OOMOL Connector 渐进式发现应用和 Action、检查 Schema 并执行已连接的 SaaS 能力；MIT、npm `0.1.4`。DSH 只保存可撤销的 OOMOL MCP Key，第三方 OAuth Token 留在 OOMOL；卸载插件不会自动断开第三方账户，Action 执行目前也没有幂等键。
 - [Ollama](https://github.com/ollama/ollama/blob/main/docs/integrations/deepseek-harness.mdx)：Ollama 官方提供的启动方式，不是 DeepSeek 官方发行包。通过 `ollama launch dsh` 安装并启动 DSH、选择 Ollama 模型和配置 Web 搜索；独立设置写入 `~/.ollama/launch/dsh/settings.yaml`，不会改动 `~/.dsh/settings.yaml`。当前标注为开发者预览。
 - [Sealos Skills](https://github.com/labring/sealos-skills)：由 Sealos 团队维护的 DSH Profile Bundle，提供应用部署、数据库、对象存储等八个云原生 Skills；实际使用会操作外部 Sealos Cloud 资源，需要账号与相关凭据，登录会写入 `~/.sealos/kubeconfig`，部分流程需放宽沙箱权限。`package.json` 声明 MIT，但仓库根目录当前缺少 `LICENSE` 文件。
 - [Nowledge Mem](https://mem.nowledge.co/integrations/deepseek-harness)：为 DSH 提供 Working Memory、提示时检索、MCP 工具和会话捕获；依赖外部 Nowledge Mem 产品与 `nmem` CLI，适合与开源插件分开评估。

--- a/README_EN.md
+++ b/README_EN.md
@@ -56,6 +56,8 @@ This project follows a curated, quality-over-quantity approach to collecting exc
 
 [DeepSeek Harness](https://deepseek.com/harness/) (also known as DSH or `dsh`) is an open-source Agent Harness project from DeepSeek AI. Built on [Cordis](https://github.com/cordiverse/cordis), it follows an **Everything is a Plugin** architecture: model adapters, tools, session logs, interfaces, and the Agent Loop can all be composed and replaced through a plugin tree.
 
+The latest verified official developer preview is [`0.1.0-rc.7`](https://github.com/deepseek-ai/deepseek-harness/tree/dsh-v0.1.0-rc.7). DSH versions shown for individual projects below represent the development or test baseline claimed by their authors and should not be treated as automatic compatibility with the latest preview.
+
 ### Launch the Web UI
 
 Install [Node.js](https://nodejs.org/) 22.19.x or 24+ (24+ recommended), then run:
@@ -194,6 +196,8 @@ The following projects provide standalone user interfaces, distribution formats,
 - [dsh-record-replay](https://github.com/humblebanana/dsh-record-replay): records macOS desktop workflows and generates Skills; currently requires Xcode Command Line Tools and a separate local `open-record-replay` source checkout.
 - [dsh-science-workbench](https://github.com/poplarity/dsh-science-workbench): reproducible science workbench that records cells, figures, feedback, and rerun lineage in a manifest, together with environment snapshots and input/output hashes; MIT and `v0.1.1`, still Early.
 - [dsh-omicos](https://github.com/omicverse/dsh-omicos): connects OmicOS bioinformatics to DSH with a persistent Python / R kernel, capability catalog, background jobs, and live execution views; GPL-3.0-only and published to npm as `0.2.1`. Analysis tools run with `permission_mode: full` and may start a local kernel; cloud-backed models and higher tiers require an OmicOS account.
+- [dsh-crew](https://github.com/ZSeven-W/dsh-crew): dispatches real DSH workers from Claude Code or Codex with progress reporting, status shards, and tier policies; MIT and npm `0.1.0-rc.1`. It writes to `~/.config/dsh-crew/status.d/`, and external model services may require API keys. It currently claims validation only against DSH `0.1.0-rc.6` and has no visible tests, so it is marked Early.
+- [dsh-trading](https://github.com/maddogfinance/dsh-trading): DSH workbench for trading research with deterministic indicators, CSV providers, and interactive charts; MIT and npm `@dsh-trading/bundle@0.1.0`. It exposes no order-execution interface and heuristically blocks fund-moving tools, but that filter is not a complete security boundary, so the project is marked Early.
 
 ### Context, Sessions, and Input
 
@@ -205,7 +209,8 @@ The following projects provide standalone user interfaces, distribution formats,
 - [dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio): edits system-prompt fragments with a live preview.
 - [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind): rewinds conversations and workspace state through a persistent Change Ledger.
 - [dsh-compaction-instant](https://github.com/KitDoesIt/dsh-compaction-instant): replaces LLM summarization with deterministic compilation and restores compressed content through `recall` / `search`; replacing the built-in compactor requires an npm alias and is a deeper runtime modification.
-- [dsh-whale-report](https://github.com/SenmuuuuW/dsh-whale-report): generates daily, weekly, monthly, yearly, and custom-range reports read-only from session event logs without rewriting session history; MIT and `v0.2.0`, still Early.
+- [toolshrink](https://github.com/unclecode/toolshrink): performs content-aware reduction for test, diff, JSON, tree, log, and install output while retaining references to originals when needed; MIT `0.1.0`. It currently requires a source build and an edit to the global `~/.dsh/cordis.patch.yml`; stored originals are removed after 24 hours, so it is marked Early.
+- [dsh-whale-report](https://github.com/SenmuuuuW/dsh-whale-report): generates daily, weekly, monthly, yearly, and custom-range reports read-only from session event logs, adding DeepTrace, cost and balance views, findings, collaboration, activity, resources, risks, and session traces in `v0.4.0`; it does not rewrite session history, is MIT-licensed, and remains Early.
 
 ### Browser, Vision, and Interface
 
@@ -236,6 +241,7 @@ The following projects provide standalone user interfaces, distribution formats,
 
 ## External Integrations
 
+- [dsh-oomol](https://github.com/oomol-lab/dsh-oomol): progressively discovers apps and actions through OOMOL Connector, inspects schemas, and executes connected SaaS capabilities; MIT and npm `0.1.4`. DSH stores only a revocable OOMOL MCP key while third-party OAuth tokens remain in OOMOL; removing the plugin does not disconnect provider accounts, and action execution currently has no idempotency key.
 - [Ollama](https://github.com/ollama/ollama/blob/main/docs/integrations/deepseek-harness.mdx): Ollama's official launcher for DSH, not a DeepSeek-official distribution. Use `ollama launch dsh` to install and start DSH, choose an Ollama model, and configure Web search; settings are stored separately in `~/.ollama/launch/dsh/settings.yaml` and do not modify `~/.dsh/settings.yaml`. Currently marked as a developer preview.
 - [Sealos Skills](https://github.com/labring/sealos-skills): a DSH Profile Bundle maintained by the Sealos team, providing eight cloud-native Skills for application deployment, databases, object storage, and related workflows. Actual use changes external Sealos Cloud resources and requires an account and relevant credentials; login writes `~/.sealos/kubeconfig`, and some flows require a relaxed sandbox. `package.json` declares MIT, but the repository currently has no root `LICENSE` file.
 - [Nowledge Mem](https://mem.nowledge.co/integrations/deepseek-harness): adds Working Memory, prompt-time retrieval, MCP tools, and session capture to DSH; depends on the external Nowledge Mem product and `nmem` CLI and should be evaluated separately from open-source plugins.

--- a/README_JA.md
+++ b/README_JA.md
@@ -56,6 +56,8 @@
 
 [DeepSeek Harness](https://deepseek.com/harness/)（DSH または `dsh`）は、DeepSeek AI が公開しているオープンソースの Agent Harness プロジェクトです。[Cordis](https://github.com/cordiverse/cordis) を基盤とし、**Everything is a Plugin（すべてがプラグイン）**というアーキテクチャを採用しています。モデルアダプター、ツール、Session ログ、インターフェース、Agent Loop は、すべてプラグインツリーを通じて組み合わせたり置き換えたりできます。
 
+現在確認できる公式 Developer Preview の最新版は [`0.1.0-rc.7`](https://github.com/deepseek-ai/deepseek-harness/tree/dsh-v0.1.0-rc.7) です。以下の各プロジェクトに記載した DSH Version は作者が実際に示した開発・テスト基準であり、最新 Preview との互換性を自動的に意味するものではありません。
+
 ### Web UI の起動
 
 [Node.js](https://nodejs.org/) 22.19.x または 24+（24+ を推奨）をインストールしてから、次を実行します。
@@ -194,6 +196,8 @@ Git リポジトリからインストールする場合は、commit を固定し
 - [dsh-record-replay](https://github.com/humblebanana/dsh-record-replay)：macOS デスクトップワークフローを記録して Skill を生成。現在は Xcode Command Line Tools と、別途用意した `open-record-replay` のローカルソースが必要。
 - [dsh-science-workbench](https://github.com/poplarity/dsh-science-workbench)：Cell、図、フィードバック、再実行の系譜を Manifest に記録し、環境 Snapshot と入出力 Hash も保存する再現可能な科学ワークベンチ。MIT、`v0.1.1` で、まだ初期段階。
 - [dsh-omicos](https://github.com/omicverse/dsh-omicos)：OmicOS のバイオインフォマティクス機能を DSH に接続し、永続 Python / R Kernel、Capability Catalog、Background Job、実行状況 View を提供。GPL-3.0-only、npm `0.2.1`。分析 Tool は `permission_mode: full` で動作し、ローカル Kernel を起動する場合がある。Cloud Model と上位 Plan には OmicOS Account が必要。
+- [dsh-crew](https://github.com/ZSeven-W/dsh-crew)：Claude Code または Codex から実際の DSH Worker を Dispatch し、進捗、Status Shard、Tier Policy を提供。MIT、npm `0.1.0-rc.1`。`~/.config/dsh-crew/status.d/` に書き込み、外部 Model Service では API Key が必要になる場合がある。現在の検証対象は DSH `0.1.0-rc.6` のみで、確認できる Test もないため初期段階。
+- [dsh-trading](https://github.com/maddogfinance/dsh-trading)：決定論的 Indicator、CSV Provider、対話型 Chart を備えた取引 Research 向け DSH Workbench。MIT、npm `@dsh-trading/bundle@0.1.0`。注文実行 Interface は公開せず、資金移動 Tool をヒューリスティックに遮断するが、完全な Security Boundary ではないため初期段階。
 
 ### コンテキスト・Session・入力
 
@@ -205,7 +209,8 @@ Git リポジトリからインストールする場合は、commit を固定し
 - [dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio)：システムプロンプト断片を編集し、リアルタイムプレビューを表示。
 - [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind)：永続的な Change Ledger に基づき、会話とワークスペース状態を巻き戻す。
 - [dsh-compaction-instant](https://github.com/KitDoesIt/dsh-compaction-instant)：LLM 要約を決定論的コンパイルに置き換え、`recall` / `search` で圧縮された内容を復元。内蔵 compactor の置換には npm alias が必要で、Runtime への比較的深い変更となる。
-- [dsh-whale-report](https://github.com/SenmuuuuW/dsh-whale-report)：Session Event Log から日次、週次、月次、年次、任意期間の Report を読み取り専用で生成し、Session 履歴は書き換えない。MIT、`v0.2.0` で、まだ初期段階。
+- [toolshrink](https://github.com/unclecode/toolshrink)：Test、Diff、JSON、Directory Tree、Log、Install Output の構造を認識して圧縮し、必要に応じて元の出力への参照を保持。MIT `0.1.0`。現在は Source Build と Global `~/.dsh/cordis.patch.yml` の編集が必要で、保存した原文は 24 時間後に削除されるため初期段階。
+- [dsh-whale-report](https://github.com/SenmuuuuW/dsh-whale-report)：Session Event Log から日次、週次、月次、任意期間の Report を読み取り専用で生成し、`v0.4.0` では DeepTrace、Cost と Balance、Finding、Collaboration、Activity、Resource、Risk、Session Trace を追加。Session 履歴は書き換えず、MIT で、まだ初期段階。
 
 ### ブラウザ・ビジョン・インターフェース
 
@@ -236,6 +241,7 @@ Git リポジトリからインストールする場合は、commit を固定し
 
 ## 外部連携
 
+- [dsh-oomol](https://github.com/oomol-lab/dsh-oomol)：OOMOL Connector を通じて App と Action を段階的に発見し、Schema を確認して接続済み SaaS の機能を実行。MIT、npm `0.1.4`。DSH が保存するのは取り消し可能な OOMOL MCP Key のみで、第三者 OAuth Token は OOMOL 側に残る。Plugin を削除しても Provider Account は切断されず、Action 実行には現時点で Idempotency Key がない。
 - [Ollama](https://github.com/ollama/ollama/blob/main/docs/integrations/deepseek-harness.mdx)：Ollama 公式が提供する起動方法であり、DeepSeek 公式の配布物ではない。`ollama launch dsh` で DSH の導入と起動、Ollama モデル選択、Web 検索設定を行う。独立設定は `~/.ollama/launch/dsh/settings.yaml` に保存され、`~/.dsh/settings.yaml` は変更しない。現在は Developer Preview と明記されている。
 - [Sealos Skills](https://github.com/labring/sealos-skills)：Sealos チームが保守する DSH Profile Bundle。アプリのデプロイ、データベース、オブジェクトストレージなど、8 個のクラウドネイティブ Skill を提供。実際の利用では外部の Sealos Cloud リソースを変更するため、アカウントと関連認証情報が必要。ログイン時には `~/.sealos/kubeconfig` へ書き込み、一部のフローではサンドボックス権限の緩和が必要。`package.json` は MIT を宣言しているが、現在リポジトリのルートに `LICENSE` ファイルはない。
 - [Nowledge Mem](https://mem.nowledge.co/integrations/deepseek-harness)：DSH に Working Memory、プロンプト時の検索、MCP ツール、Session キャプチャを追加。外部製品 Nowledge Mem と `nmem` CLI に依存するため、オープンソースプラグインとは分けて評価するのが適切。


### PR DESCRIPTION
## What changed

- document the verified DeepSeek Harness `0.1.0-rc.7` preview baseline
- add `dsh-oomol`, `dsh-crew`, `dsh-trading`, and `toolshrink` with maturity and permission boundaries
- update `dsh-whale-report` from `v0.2.0` to `v0.4.0`
- keep Chinese, English, and Japanese README coverage aligned

## Validation

- `git diff --check`
- verified identical GitHub repository sets across all three READMEs
- rechecked source repositories, licenses, the official rc.7 tag, and published npm versions

Existing untracked banner drafts are intentionally excluded.
