### PR TITLE
docs: 新增 dsh-trading-toolkit（A股+美股行情工具箱）

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ dsh --profile web --dump-config
 - [dsh-omicos](https://github.com/omicverse/dsh-omicos)：把 OmicOS 生物信息学能力接入 DSH，提供持久 Python / R 内核、能力目录、后台任务和执行过程视图；GPL-3.0-only、npm `0.2.1`。分析工具以 `permission_mode: full` 运行并可能启动本地内核，云模型和高级套餐需要 OmicOS 账号。
 - [dsh-crew](https://github.com/ZSeven-W/dsh-crew)：从 Claude Code 或 Codex 调度真实 DSH Worker，并提供进度、状态分片和分层策略；MIT、npm `0.1.0-rc.1`，会写入 `~/.config/dsh-crew/status.d/`，外部模型服务可能需要 API Key。当前仅声明在 DSH `0.1.0-rc.6` 验证，且尚无可见测试，标注为早期。
 - [dsh-trading](https://github.com/maddogfinance/dsh-trading)：面向交易研究的 DSH 工作台，提供确定性指标、CSV 数据源和交互式图表；MIT、npm `@dsh-trading/bundle@0.1.0`。项目不提供订单执行接口，并以启发式规则拦截资金移动类工具，但该拦截并非完备安全边界，标注为早期。
+- [dsh-trading-toolkit](https://github.com/kentleenot/dsh-trading-toolkit)：A股+美股行情工具箱，提供实时行情、OHLCV K线（分钟到月线，前/后复权）、ADX 三状态市场分类（趋势/震荡/噪声）与回测预览；东方财富数据源免 Key 直连，只读永不下单；MIT。
 
 ### 上下文、会话与输入
 


### PR DESCRIPTION
新增精选插件 **dsh-trading-toolkit**：

- A股+美股行情工具箱（实时行情 / OHLCV K线 / ADX 三状态信号 / 回测预览）
- 数据源东方财富，免 Key 免代理，国内直连
- 纯只读，永不下单；MIT 许可

仓库：https://github.com/kentleenot/dsh-trading-toolkit（topic: dsh-plugin）