### PR TITLE
add dsh-review: independent cross-review skill via DeepSeek Harness + V4 Flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ dsh --profile web --dump-config
 ### 工作流与 Agent
 
 - [dsh-toolkit](https://github.com/omdsh-dev/dsh-toolkit)：时间、编码、JSON、计算器、CSV、正则、Markdown、Diff 等确定性工具合集。
+- [dsh-review](https://github.com/Tinzlu/dsh-review)：把 DeepSeek Harness headless 封装为 Codex 的独立交叉审查技能，用 V4 Flash 对 diff / 文件 / 仓库做跨模型审查；MIT、`v0.1.0`，需 Node.js 与 `DEEPSEEK_API_KEY`，依赖 DSH 开发者预览版，审查内容会发送至 DeepSeek API。
 - [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research)：面向 DSH 的自适应深度研究编排器。
 - [dsh-101](https://github.com/bill9109/dsh-101)：在 DSH 中阅读和理解官方文档的学习模式。
 - [dsh-auto-approval](https://github.com/Andy8647/dsh-auto-approval)：使用规则和模型分类工具调用，输出 `allow / deny` 自动审批决策。

--- a/README_EN.md
+++ b/README_EN.md
@@ -187,6 +187,7 @@ The following projects provide standalone user interfaces, distribution formats,
 ### Workflows and Agents
 
 - [dsh-toolkit](https://github.com/omdsh-dev/dsh-toolkit): deterministic tools for time, encoding, JSON, calculations, CSV, regex, Markdown, Diff, and more.
+- [dsh-review](https://github.com/Tinzlu/dsh-review): packages DeepSeek Harness headless as a Codex skill for independent cross-review of diffs, files, or whole repos with V4 Flash; MIT and `v0.1.0`. Requires Node.js and `DEEPSEEK_API_KEY`; depends on the DSH developer preview, and review content is sent to the DeepSeek API.
 - [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research): adaptive deep-research orchestrator for DSH.
 - [dsh-101](https://github.com/bill9109/dsh-101): learning mode for reading and understanding the official documentation inside DSH.
 - [dsh-auto-approval](https://github.com/Andy8647/dsh-auto-approval): classifies tool calls with rules and models, then returns `allow / deny` approval decisions.

--- a/README_JA.md
+++ b/README_JA.md
@@ -187,6 +187,7 @@ Git リポジトリからインストールする場合は、commit を固定し
 ### ワークフローと Agent
 
 - [dsh-toolkit](https://github.com/omdsh-dev/dsh-toolkit)：時刻、エンコーディング、JSON、計算、CSV、正規表現、Markdown、Diff などの決定論的ツール集。
+- [dsh-review](https://github.com/Tinzlu/dsh-review)：DeepSeek Harness の headless を Codex スキルにした独立クロスレビュー。V4 Flash で diff・ファイル・リポジトリ全体をレビュー。MIT・`v0.1.0`。Node.js と `DEEPSEEK_API_KEY` が必要で、DSH の開発者プレビューに依存。レビュー内容は DeepSeek API に送信されます。
 - [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research)：DSH 向けの適応型ディープリサーチオーケストレーター。
 - [dsh-101](https://github.com/bill9109/dsh-101)：DSH 内で公式ドキュメントを読み、理解するための学習モード。
 - [dsh-auto-approval](https://github.com/Andy8647/dsh-auto-approval)：ルールとモデルでツール呼び出しを分類し、`allow / deny` の自動承認判断を返す。


### PR DESCRIPTION
Adds [dsh-review](https://github.com/Tinzlu/dsh-review) to the Selected Plugins → Workflows and Agents section (README.md / README_EN.md / README_JA.md).

dsh-review packages DeepSeek Harness headless as a Codex skill: it reviews a git diff, files, or a whole repo with DeepSeek V4 Flash as an independent second opinion (different model family + different harness). MIT, v0.1.0.