### PR TITLE
docs: add dsh-meow-smooth to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ dsh --profile web --dump-config
 
 ### 浏览器、视觉与界面
 
+- [dsh-meow-smooth](https://github.com/Phant0Meow/dsh-meow-smooth)：手机优先的 DSH 前端体验优化（输入框自动折叠、手机回车换行、侧边栏/顶部栏压缩、设置页、禁缩放回弹），以及长任务完成/权限申请/提问的通知（页面卡片、Web Push、webhook）；零 dsh 本体改动。
 - [dsh-browser](https://github.com/Lum1104/dsh-browser)：Chrome 侧边栏扩展，让 DSH 直接操作当前浏览器页面。
 - [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit)：图片问答、长截图 OCR、UI 还原、Grounding 和像素对比。
 - [dsh-computer-use](https://github.com/Anionex/dsh-computer-use)：原生 macOS Computer Use Bundle，优先使用 Accessibility，拒绝过期观察并按应用、Session 和操作范围管理权限；当前为早期 `0.1.0`，需从源码检出目录安装。

--- a/README_EN.md
+++ b/README_EN.md
@@ -219,6 +219,7 @@ The following projects provide standalone user interfaces, distribution formats,
 
 ### Browser, Vision, and Interface
 
+- [dsh-meow-smooth](https://github.com/Phant0Meow/dsh-meow-smooth): mobile-first UX polish for the DSH Web UI (composer auto-fold, Enter-as-newline on phones, compact sidebar/header, settings page, zoom and overscroll lock) plus notifications for task completion / permission requests / questions via in-page cards, Web Push, and webhook; zero dsh changes.
 - [dsh-browser](https://github.com/Lum1104/dsh-browser): Chrome sidebar extension that lets DSH operate the current browser page directly.
 - [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit): image Q&A, long-screenshot OCR, UI reconstruction, grounding, and pixel comparison.
 - [dsh-computer-use](https://github.com/Anionex/dsh-computer-use): native macOS Computer Use Bundle that prioritizes Accessibility, rejects stale observations, and scopes permissions by app, Session, and action; currently an early `0.1.0` release installed from a source checkout.

--- a/README_JA.md
+++ b/README_JA.md
@@ -219,6 +219,7 @@ Git リポジトリからインストールする場合は、commit を固定し
 
 ### ブラウザ・ビジョン・インターフェース
 
+- [dsh-meow-smooth](https://github.com/Phant0Meow/dsh-meow-smooth)：モバイル優先の DSH Web UI 最適化（入力欄の自動折りたたみ、モバイルでの Enter=改行、サイドバー/ヘッダー圧縮、設定画面、ズーム・バウンス無効化）に加え、長タスクの完了・権限要求・質問の通知（ページ内カード、Web Push、webhook）を提供。dsh 本体への変更は一切なし。
 - [dsh-browser](https://github.com/Lum1104/dsh-browser)：DSH から現在のブラウザページを直接操作できる Chrome サイドバー拡張。
 - [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit)：画像 Q&A、長いスクリーンショットの OCR、UI 再現、Grounding、ピクセル比較。
 - [dsh-computer-use](https://github.com/Anionex/dsh-computer-use)：Accessibility を優先し、古い観測を拒否し、アプリ・Session・操作単位で権限を管理するネイティブ macOS Computer Use Bundle。現在は初期 `0.1.0` で、ソースチェックアウトからインストールする必要がある。


### PR DESCRIPTION
Adding [dsh-meow-smooth (喵丝滑)](https://github.com/Phant0Meow/dsh-meow-smooth) to Browser, Vision, and Interface in all three languages (zh/en/ja): mobile-first UX polish for the DSH Web UI plus task/permission/question notifications via in-page cards, Web Push, and webhook — zero dsh changes. npm: \meow-smooth@0.2.0\.