### PR TITLE
新增精选插件：dsh-web-app-launcher（浏览器、视觉与界面）

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ dsh --profile web --dump-config
 - [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize)：在对话流中生成沙箱化的可交互 HTML 卡片。
 - [dsh-notification](https://github.com/omdsh-dev/dsh-notification)：按任务结果和关键词配置桌面通知。
 - [dsh-share](https://github.com/hellodigua/dsh-share)：一键生成并分享 DSH 对话内容。
+- [dsh-web-app-launcher](https://github.com/sylkmpo/dsh-web-app-launcher)：Windows 插件，让 dsh web 像普通桌面软件一样运行：本质是原生 Web（无 Electron、无二次打包、无 fork），视觉上是桌面软件——首次运行自动创建桌面快捷方式，双击即以 Edge/Chrome/Brave/Vivaldi 的无边框应用窗口（无标签栏/地址栏）打开 Web UI，关闭窗口即退出 Harness；MIT，经 GitHub 安装（`dsh plugin --profile web add github:sylkmpo/dsh-web-app-launcher`），需 Windows 10/11。
 
 ### 沙箱与执行
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -233,6 +233,7 @@ The following projects provide standalone user interfaces, distribution formats,
 - [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize): generates sandboxed, interactive HTML cards in the conversation stream.
 - [dsh-notification](https://github.com/omdsh-dev/dsh-notification): configurable desktop notifications based on task outcomes and keywords.
 - [dsh-share](https://github.com/hellodigua/dsh-share): generates and shares DSH conversation content in one click.
+- [dsh-web-app-launcher](https://github.com/sylkmpo/dsh-web-app-launcher): Windows plugin that runs dsh web like an ordinary desktop app — the native web UI under the hood (no Electron, no repackaging, no fork), presented as a desktop application: a desktop shortcut is created automatically on first run, and double-clicking opens the Web UI in a frameless Edge/Chrome/Brave/Vivaldi app window (no tab bar or address bar) that exits the harness when closed; MIT, installed from GitHub via `dsh plugin --profile web add github:sylkmpo/dsh-web-app-launcher`; requires Windows 10/11.
 
 ### Sandboxing and Execution
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -233,6 +233,7 @@ Git リポジトリからインストールする場合は、commit を固定し
 - [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize)：会話ストリーム内にサンドボックス化されたインタラクティブ HTML カードを生成。
 - [dsh-notification](https://github.com/omdsh-dev/dsh-notification)：タスク結果とキーワードに応じて設定できるデスクトップ通知。
 - [dsh-share](https://github.com/hellodigua/dsh-share)：DSH の会話内容をワンクリックで生成・共有。
+- [dsh-web-app-launcher](https://github.com/sylkmpo/dsh-web-app-launcher)：Windows 向けプラグインで、dsh web を普通のデスクトップアプリのように実行する。本質はネイティブ Web（Electron なし、リパッケージなし、fork なし）、見た目はデスクトップソフト——初回起動でデスクトップショートカットを自動作成し、ダブルクリックで Edge/Chrome/Brave/Vivaldi のフレームレスアプリウィンドウ（タブバー/アドレスバーなし）で Web UI を開き、ウィンドウを閉じると Harness も終了。MIT、GitHub から導入（`dsh plugin --profile web add github:sylkmpo/dsh-web-app-launcher`）、Windows 10/11 必須。
 
 ### サンドボックスと実行
 


### PR DESCRIPTION
在「精选插件 → 浏览器、视觉与界面」小节新增 [dsh-web-app-launcher](https://github.com/sylkmpo/dsh-web-app-launcher)（README / README_EN / README_JA 三个语言版本已同步更新）：

- Windows 插件，让 `dsh web` 像普通桌面软件一样运行：本质是原生 Web（无 Electron、无二次打包、无 fork），视觉上是桌面软件
- 首次运行自动创建桌面快捷方式，双击即以无边框应用窗口（无标签栏/地址栏）打开 Web UI，关闭窗口即退出 Harness
- 安装：`dsh plugin --profile web add github:sylkmpo/dsh-web-app-launcher`（Windows 10/11），MIT