### PR TITLE
添加 dsh-split-screen（分屏工作区）

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ dsh --profile web --dump-config
 - [dsh-locale-ja](https://github.com/fang2hou/dsh-locale-ja)：为 DSH Web 增加日本语界面与系统日文字体，覆盖 29 个命名空间、721 条 UI 字符串；MIT、npm / Release `0.4.3`、Node.js 22+，Peer 依赖锁定 `@deepseek-ai/dsh-client-locale ^0.1.1-rc.2`，仓库测试、字典漂移检查和每日 `next` DSH E2E 均通过。插件只挂载客户端本地化模块，不新增 Host 路由、凭据或外部服务。
 - [dsh-share](https://github.com/hellodigua/dsh-share)：一键生成并分享 DSH 对话内容。
 
+- [dsh-split-screen](https://github.com/YEYEYEYESHIFU/dsh-split-screen)：分屏工作区，多个会话并排聊天，面板观感与原生对话完全一致；Alt+T 切换紧凑 TUI 输入模式，Alt+Shift+方向键切换面板焦点；MIT、npm / Release `1.0.0`。
 ### 沙箱与执行
 
 - [sandbox-micro](https://github.com/omdsh-dev/sandbox-micro)：提供 fail-closed 的 microsandbox microVM 能力；安装后 Provider 与模型工具均默认关闭，必须分别显式启用，平台检查失败时不会降级为无约束宿主执行。含测试目录但尚无正式 Release；`package.json` 声明 BSD-3-Clause，但仓库根目录没有 `LICENSE` 文件，标注为早期。


### PR DESCRIPTION
## 添加 dsh-split-screen（浏览器、视觉与界面）

- 仓库：https://github.com/YEYEYEYESHIFU/dsh-split-screen
- npm：https://www.npmjs.com/package/dsh-split-screen（v1.0.0，MIT）

分屏工作区：多个会话并排聊天，面板观感与原生 DeepSeek 对话完全一致；Alt+T 切换紧凑 TUI 输入模式，Alt+Shift+方向键切换面板焦点；支持图片粘贴与拖拽附件、排队消息与 todos；布局持久化。MIT、npm / Release `1.0.0`。
